### PR TITLE
Quick fix to JSONP middleware bug

### DIFF
--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -41,7 +41,7 @@ module Rack
     private
     
     def is_json?(headers)
-      headers['Content-Type'].include?('application/json')
+      headers.key?('Content-Type') && headers['Content-Type'].include?('application/json')
     end
     
     def has_callback?(request)

--- a/test/spec_rack_jsonp.rb
+++ b/test/spec_rack_jsonp.rb
@@ -69,5 +69,13 @@ context "Rack::JSONP" do
     body = Rack::JSONP.new(app).call(request).last
     body.should.equal [test_body]
   end
+  
+  specify "should not change anything if there is no Content-Type header" do
+    test_body = '<html><body>404 Not Found</body></html>'
+    app = lambda { |env| [404, {}, [test_body]] }
+    request = Rack::MockRequest.env_for("/", :params => "callback=foo", 'HTTP_ACCEPT' => 'application/json')
+    body = Rack::JSONP.new(app).call(request).last
+    body.should.equal [test_body]
+  end  
 
 end


### PR DESCRIPTION
Hi there, 

The JSONP middleware was breaking when the Content-Type header was missing. This is a valid situation for 204 and 304 responses.

Have added a fix and test, seems to work.

Cheers,

Matt
