### PR TITLE
Just added TLS support for mailexceptions middleware

### DIFF
--- a/test/mail_settings.rb
+++ b/test/mail_settings.rb
@@ -10,3 +10,11 @@ TEST_SMTP = nil
 #   :user_name      => nil,
 #   :password       => nil
 # }
+#TEST_SMTP_TLS = {
+#    :server         => 'smtp.gmail.com',
+#    :domain         => 'gmail.com',
+#    :port           => 587,
+#    :authentication => 'plain',
+#    :user_name      => nil,
+#    :password       => nil,
+#}


### PR DESCRIPTION
In a long run mailexceptions should rely on a mailing library instead
If there's one I will work on that.
