### PR TITLE
Fix bug with domain caching for common cookies in production

### DIFF
--- a/lib/rack/contrib/common_cookies.rb
+++ b/lib/rack/contrib/common_cookies.rb
@@ -19,10 +19,8 @@ module Rack
     private
 
     def domain
-      @domain ||= begin
-        @host =~ DOMAIN_REGEXP
-        ".#{$1}.#{$2}"
-      end
+      @host =~ DOMAIN_REGEXP
+      ".#{$1}.#{$2}"
     end
 
     def share_cookie(headers)


### PR DESCRIPTION
The change is very simple - removal of domain memoization in common_cookies.rb
