### PR TITLE
Fix PostBodyContentTypeParser's content-type matching

### DIFF
--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -29,8 +29,8 @@ module Rack
     end
 
     def call(env)
-      if Rack::Request.new(env).media_type == APPLICATION_JSON
-        env.update(FORM_HASH => JSON.parse(env[POST_BODY].read), FORM_INPUT => env[POST_BODY])
+      if Rack::Request.new(env).media_type == APPLICATION_JSON && (body = env[POST_BODY].read).length != 0
+        env.update(FORM_HASH => JSON.parse(body), FORM_INPUT => env[POST_BODY])
       end
       @app.call(env)
     end


### PR DESCRIPTION
This bug's been around a while (http://jaywiggins.com/2010/04/lost-sleep-over-json-and-rackpostbodycontenttypeparser/), but no-one seems to have fixed it. So here it is.

The content type match on PostBodyContentTypeParser is a bit naïve, so I've changed it to use Rack::Request's content_type parsing, fixing a bug if the browser includes a charset or some-such media-type parameter.
