### PR TITLE
Close SMTP connections after we're done with them

### DIFF
--- a/lib/rack/contrib/mailexceptions.rb
+++ b/lib/rack/contrib/mailexceptions.rb
@@ -78,10 +78,10 @@ module Rack
         server.enable_starttls 
       end
 
-      server.start smtp[:domain], smtp[:user_name], smtp[:password], smtp[:authentication]
-
-      mail.to.each do |recipient|
-        server.send_message mail.to_s, mail.from, recipient
+      server.start smtp[:domain], smtp[:user_name], smtp[:password], smtp[:authentication] do |smtp|
+        mail.to.each do |recipient|
+          smtp.send_message mail.to_s, mail.from, recipient
+        end
       end
     end
 


### PR DESCRIPTION
Otherwise a heavily erroring app can cause resource exhaustion.