### PR TITLE
JSONP: Always escape U+2028 and U+2029

### DIFF
--- a/test/spec_rack_jsonp.rb
+++ b/test/spec_rack_jsonp.rb
@@ -51,6 +51,15 @@ context "Rack::JSONP" do
       headers = Rack::JSONP.new(app).call(request)[1]
       headers['Content-Type'].should.equal('application/javascript')
     end
+
+    specify "should not allow literal U+2028 or U+2029" do
+      test_body = "{\"bar\":\"\u2028 and \u2029\"}"
+      callback = 'foo'
+      app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
+      request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
+      body = Rack::JSONP.new(app).call(request).last
+      body.join.should.not.match(/\u2028|\u2029/)
+    end
     
     context "but is empty" do
       specify "should " do


### PR DESCRIPTION
I just discovered a "bug" in JSON:

JSON is not a true subset of JavaScript because of two tiny whitespace unicode characters: U+2028 and U+2029. In ECMA-262 they are defined as "Line Terminator Characters" (see 7.3 Line Terminator) and are therefore equivalent of \n and \r. That means they are _not_ valid in the middle of a string.

According to JSON U+2029 and U+2029 are just two regular Unicode characters and are therefore _valid_ in the middle of a string. This is usually not a problem as long as you use a proper JSON parser, but in the case of JSONP the browser _is_ the JSON parser.

This pull request will simply escape any U+2028/9 (to `\u2028/9`) and fixes this issue.

For a "real-world" example of this issue, you can try to call the JSONP-API of GitHub to the YARD-repository (whose description happens to include U+2028):

```
<script src="https://github.com/api/v2/json/repos/show/lsegal/yard?callback=alert"></script>
```
