### PR TITLE
Fix to allow :duration as a float (eg :duration => 0.2 ~ 1 Week)

### DIFF
--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -87,7 +87,7 @@ module Rack
     end
 
     def duration_in_seconds
-      60 * 60 * 24 * 365 * @cache_duration
+      (60 * 60 * 24 * 365 * @cache_duration).to_i
     end
   end
 end


### PR DESCRIPTION
While I have it working I wanted to have more control over the expire time. Kind of weird but works ;)
