### PR TITLE
Do not mutate options in TryStatic.new

### DIFF
--- a/lib/rack/contrib/try_static.rb
+++ b/lib/rack/contrib/try_static.rb
@@ -17,7 +17,7 @@ module Rack
 
     def initialize(app, options)
       @app = app
-      @try = ['', *options.delete(:try)]
+      @try = ['', *options[:try]]
       @static = ::Rack::Static.new(
         lambda { |_| [404, {}, []] },
         options)

--- a/test/spec_rack_try_static.rb
+++ b/test/spec_rack_try_static.rb
@@ -43,4 +43,14 @@ describe "Rack::TryStatic" do
       res.body.strip.should == "existing.html"
     end
   end
+
+  context 'when sharing options' do
+    it 'should not mutate given options' do
+      org_options = build_options  :try => ['/index.html']
+      given_options = org_options.dup
+      request(given_options).get('/documents').should.be.ok
+      request(given_options).get('/documents').should.be.ok
+      given_options.should == org_options
+    end
+  end
 end


### PR DESCRIPTION
If I have a following rackup file:

``` ruby
require 'rack'
require 'rack/contrib/try_static'

use Rack::ShowExceptions

map '/foo' do
  use Rack::TryStatic, :root => File.expand_path('public', File.dirname(__FILE__)), :urls => %w{/}, :try => %w{.html index.html /index.html}
end

run proc { [200, {'Content-Type' => 'text/html', 'Content-Length' => '3'}, ["404"]] }
```

And I run it with `rackup`, issuing the following requests:
1. GET /foo
2. GET /bar
3. GET /foo

In step 1, TryStatic.new modifies the options, but returns the static file correctly. In step 3, the same options instance gets passed to TryStatic.new. Then, there is no `:try` key left, because it was removed in step 1. This causes the static file not be returned.

This patch changes TryStatic#initialize so that it does not change the options given to it.

Also, commit 04ced706c of the patch is possibly related to GH-48.
