### PR TITLE
Rewind the stream that holds the post body after reading from it

### DIFF
--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -30,9 +30,9 @@ module Rack
 
     def call(env)
       if Rack::Request.new(env).media_type == APPLICATION_JSON && (body = env[POST_BODY].read).length != 0
+        env[POST_BODY].rewind # somebody might try to read this stream
         env.update(FORM_HASH => JSON.parse(body), FORM_INPUT => env[POST_BODY])
       end
-      env[POST_BODY].rewind # somebody might try to read this stream
       @app.call(env)
     end
 


### PR DESCRIPTION
Rewind the stream that holds the post body. Rails also will try to read the env[POST_BODY] it will crap out with: MultiJson::DecodeError (A JSON text must at least contain two octets!) in activesupport (3.2.2) lib/active_support/json/decoding.rb:12:in `decode'
