### PR TITLE
HostMeta is missing from autoload

### DIFF
--- a/lib/rack/contrib.rb
+++ b/lib/rack/contrib.rb
@@ -14,6 +14,7 @@ module Rack
   autoload :CSSHTTPRequest,             "rack/contrib/csshttprequest"
   autoload :Deflect,                    "rack/contrib/deflect"
   autoload :ExpectationCascade,         "rack/contrib/expectation_cascade"
+  autoload :HostMeta,                   "rack/contrib/host_meta"
   autoload :GarbageCollector,           "rack/contrib/garbagecollector"
   autoload :JSONP,                      "rack/contrib/jsonp"
   autoload :LighttpdScriptNameFix,      "rack/contrib/lighttpd_script_name_fix"


### PR DESCRIPTION
This is a small change to include HostMeta in the rack contrib autoloads.
