### PR TITLE
Remove deprecated 'rake/rdoctask', replace with new invocation.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 # Rakefile for Rack::Contrib.  -*-ruby-*-
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/testtask'
 
 desc "Run all the tests"
@@ -26,7 +26,7 @@ task :fulltest do
 end
 
 desc "Generate RDoc documentation"
-Rake::RDocTask.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.options << '--line-numbers' << '--inline-source' <<
     '--main' << 'README' <<
     '--title' << 'Rack Contrib Documentation' <<

--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -101,6 +101,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'test-spec', '>= 0.9.0'
   s.add_development_dependency 'tmail', '>= 1.2'
   s.add_development_dependency 'json', '>= 1.1'
+  s.add_development_dependency 'rake', '>= 10.0.3'
+  s.add_development_dependency 'rdoc', '>= 3.12'
 
   s.has_rdoc = true
   s.homepage = "http://github.com/rack/rack-contrib/"


### PR DESCRIPTION
Required for rake 10.