### PR TITLE
Switch out test-spec for rspec 2 for Ruby 1.9 compatability

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -78,17 +78,15 @@ components included. The following example shows what a simple rackup
 
 To contribute to the project, begin by cloning the repo and installing the necessary gems:
 
-    gem install json rack ruby-prof test-spec test-unit
+    gem install json rack ruby-prof rspec
 
 To run the entire test suite, run 
     rake test
 
 To run a specific component's tests run
-    specrb -Ilib:test -w test/spec_rack_thecomponent.rb
+    rspec -Ilib:test test/spec_rack_thecomponent.rb
 
-This works on ruby 1.8.7 but has problems under ruby 1.9.x. 
-
-TODO: instructions for 1.9.x and include bundler
+TODO: include bundler
 
 === Links
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,27 +2,11 @@
 require 'rake/rdoctask'
 require 'rake/testtask'
 
+task :default => [:spec]
+
 desc "Run all the tests"
-task :default => [:test]
-
-desc "Generate RDox"
-task "RDOX" do
-  sh "specrb -Ilib:test -a --rdox >RDOX"
-end
-
-desc "Run specs with test/unit style output"
-task :test do
-  sh "specrb -Ilib:test -w #{ENV['TEST'] || '-a'} #{ENV['TESTOPTS']}"
-end
-
-desc "Run specs with specdoc style output"
 task :spec do
-  sh "specrb -Ilib:test -s -w #{ENV['TEST'] || '-a'} #{ENV['TESTOPTS']}"
-end
-
-desc "Run all the tests"
-task :fulltest do
-  sh "specrb -Ilib:test -w #{ENV['TEST'] || '-a'} #{ENV['TESTOPTS']}"
+  sh "rspec -Ilib:test #{ENV['TEST'] || 'test/spec_*.rb'} #{ENV['TESTOPTS']}"
 end
 
 desc "Generate RDoc documentation"
@@ -37,8 +21,6 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/rack/*.rb')
   rdoc.rdoc_files.include('lib/rack/*/*.rb')
 end
-task :rdoc => ["RDOX"]
-
 
 # PACKAGING =================================================================
 

--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -98,7 +98,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[README.rdoc COPYING]
   s.add_dependency 'rack', '>= 0.9.1'
-  s.add_development_dependency 'test-spec', '>= 0.9.0'
+  s.add_development_dependency 'rspec', '>= 2.10.0'
   s.add_development_dependency 'tmail', '>= 1.2'
   s.add_development_dependency 'json', '>= 1.1'
 

--- a/test/spec_rack_accept_format.rb
+++ b/test/spec_rack_accept_format.rb
@@ -1,9 +1,8 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/accept_format'
 require 'rack/mime'
 
-context "Rack::AcceptFormat" do
+describe "Rack::AcceptFormat" do
   app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
 
   specify "should do nothing when a format extension is already provided" do

--- a/test/spec_rack_access.rb
+++ b/test/spec_rack_access.rb
@@ -1,10 +1,9 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/access'
 
-context "Rack::Access" do
+describe "Rack::Access" do
 
-  setup do
+  before do
     @app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ['hello']] }
     @mock_addr_1 = '111.111.111.111'
     @mock_addr_2 = '192.168.1.222'
@@ -23,62 +22,62 @@ context "Rack::Access" do
   specify "default configuration should deny non-local requests" do
     app = middleware
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
   end
 
   specify "default configuration should allow requests from 127.0.0.1" do
     app = middleware
     status, headers, body = app.call(mock_env(@mock_addr_localhost))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
   end
 
   specify "should allow remote addresses in allow_ipmasking" do
     app = middleware('/' => [@mock_addr_1])
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
   end
 
   specify "should deny remote addresses not in allow_ipmasks" do
     app = middleware('/' => [@mock_addr_1])
     status, headers, body = app.call(mock_env(@mock_addr_2))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
   end
 
   specify "should allow remote addresses in allow_ipmasks range" do
     app = middleware('/' => [@mock_addr_range])
     status, headers, body = app.call(mock_env(@mock_addr_2))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
   end
 
   specify "should deny remote addresses not in allow_ipmasks range" do
     app = middleware('/' => [@mock_addr_range])
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
   end
 
   specify "should allow remote addresses in one of allow_ipmasking" do
     app = middleware('/' => [@mock_addr_range, @mock_addr_localhost])
 
     status, headers, body = app.call(mock_env(@mock_addr_2))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_localhost))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
   end
 
   specify "should deny remote addresses not in one of allow_ipmasks" do
     app = middleware('/' => [@mock_addr_range, @mock_addr_localhost])
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
   end
 
   specify "handles paths correctly" do
@@ -89,66 +88,66 @@ context "Rack::Access" do
     })
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/qux"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo"))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/"))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/bar"))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/bar"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
     status, headers, body = app.call(mock_env(@mock_addr_2, "/foo/bar"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/bar/"))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/bar/"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo///bar//quux"))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo///bar//quux"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/quux"))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/quux"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/bar"))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
     status, headers, body = app.call(mock_env(@mock_addr_1, "/bar").merge('HTTP_HOST' => 'foo.org'))
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/bar").merge('HTTP_HOST' => 'foo.org'))
-    status.should.equal 200
-    body.should.equal ['hello']
+    status.should eq(200)
+    body.should eq(['hello'])
   end
 end

--- a/test/spec_rack_backstage.rb
+++ b/test/spec_rack_backstage.rb
@@ -1,17 +1,16 @@
-require 'test/spec'
 require 'rack/builder'
 require 'rack/mock'
 require 'rack/contrib/backstage'
 
-context "Rack::Backstage" do
+describe "Rack::Backstage" do
   specify "shows maintenances page if present" do
     app = Rack::Builder.new do
       use Rack::Backstage, 'test/Maintenance.html'
       run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.should.equal('Under maintenance.')
-    response.status.should.equal(503)
+    response.body.should eq('Under maintenance.')
+    response.status.should eq(503)
   end
 
   specify "passes on request if page is not present" do
@@ -20,7 +19,7 @@ context "Rack::Backstage" do
       run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.should.equal('Hello, World!')
-    response.status.should.equal(200)
+    response.body.should eq('Hello, World!')
+    response.status.should eq(200)
   end
 end

--- a/test/spec_rack_callbacks.rb
+++ b/test/spec_rack_callbacks.rb
@@ -1,4 +1,3 @@
-require 'test/spec'
 require 'rack/mock'
 
 class Flame
@@ -37,7 +36,7 @@ class TheEnd
   end
 end
 
-context "Rack::Callbacks" do
+describe "Rack::Callbacks" do
   specify "works for love and small stack trace" do
     callback_app = Rack::Callbacks.new do
       before Flame
@@ -55,11 +54,11 @@ context "Rack::Callbacks" do
 
     response = Rack::MockRequest.new(app).get("/")
 
-    response.body.should.equal 'F Lifo..with love'
+    response.body.should eq('F Lifo..with love')
 
-    $old_status.should.equal 200
-    response.status.should.equal 201
+    $old_status.should eq(200)
+    response.status.should eq(201)
 
-    response.headers['last'].should.equal 'TheEnd'
+    response.headers['last'].should eq('TheEnd')
   end
 end

--- a/test/spec_rack_common_cookies.rb
+++ b/test/spec_rack_common_cookies.rb
@@ -1,11 +1,10 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/builder'
 require 'rack/contrib/common_cookies'
 
-context Rack::CommonCookies do
+describe Rack::CommonCookies do
 
-  setup do
+  before do
     @app = Rack::Builder.new do
       use Rack::CommonCookies
       run lambda {|env| [200, {'Set-Cookie' => env['HTTP_COOKIE']}, []] }

--- a/test/spec_rack_config.rb
+++ b/test/spec_rack_config.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/config'
 
-context "Rack::Config" do
+describe "Rack::Config" do
 
   specify "should accept a block that modifies the environment" do
     app = Rack::Builder.new do
@@ -16,7 +15,7 @@ context "Rack::Config" do
       }
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.should.equal('hello')
+    response.body.should eq('hello')
   end
 
 end

--- a/test/spec_rack_contrib.rb
+++ b/test/spec_rack_contrib.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/contrib'
 
-context "Rack::Contrib" do
+describe "Rack::Contrib" do
   specify "should expose release" do
-    Rack::Contrib.should.respond_to :release
+    Rack::Contrib.should respond_to :release
   end
 end

--- a/test/spec_rack_cookies.rb
+++ b/test/spec_rack_cookies.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/cookies'
 
-context "Rack::Cookies" do
+describe "Rack::Cookies" do
   specify "should be able to read received cookies" do
     app = lambda { |env|
       cookies = env['rack.cookies']
@@ -12,7 +11,7 @@ context "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/', 'HTTP_COOKIE' => 'foo=bar;quux=h&m')
-    response.body.should.equal('foo: bar, quux: h&m')
+    response.body.should eq('foo: bar, quux: h&m')
   end
 
   specify "should be able to set new cookies" do
@@ -25,7 +24,7 @@ context "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/')
-    response.headers['Set-Cookie'].should.equal("quux=h%26m; path=/\nfoo=bar; path=/")
+    response.headers['Set-Cookie'].should eq("quux=h%26m; path=/\nfoo=bar; path=/")
   end
 
   specify "should be able to set cookie with options" do
@@ -37,7 +36,7 @@ context "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/')
-    response.headers['Set-Cookie'].should.equal('foo=bar; path=/login; secure')
+    response.headers['Set-Cookie'].should eq('foo=bar; path=/login; secure')
   end
 
   specify "should be able to delete received cookies" do
@@ -50,7 +49,7 @@ context "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/', 'HTTP_COOKIE' => 'foo=bar;quux=h&m')
-    response.body.should.equal('foo: , quux: h&m')
-    response.headers['Set-Cookie'].should.equal('foo=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT')
+    response.body.should eq('foo: , quux: h&m')
+    response.headers['Set-Cookie'].should eq('foo=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT')
   end
 end

--- a/test/spec_rack_csshttprequest.rb
+++ b/test/spec_rack_csshttprequest.rb
@@ -1,4 +1,3 @@
-require 'test/spec'
 require 'rack/mock'
 
 begin
@@ -18,21 +17,21 @@ begin
         PATH_INFO ends with '.chr'" do
       request = Rack::MockRequest.env_for("/blah.chr", :lint => true, :fatal => true)
       Rack::CSSHTTPRequest.new(@app).call(request)
-      request['csshttprequest.chr'].should.equal true
+      request['csshttprequest.chr'].should eq(true)
     end
 
     specify "env['csshttprequest.chr'] should be set to true when \
         request parameter _format == 'chr'" do
       request = Rack::MockRequest.env_for("/?_format=chr", :lint => true, :fatal => true)
       Rack::CSSHTTPRequest.new(@app).call(request)
-      request['csshttprequest.chr'].should.equal true
+      request['csshttprequest.chr'].should eq(true)
     end
 
     specify "should not change the headers or response when !env['csshttprequest.chr']" do
       request = Rack::MockRequest.env_for("/", :lint => true, :fatal => true)
       status, headers, response = Rack::CSSHTTPRequest.new(@app).call(request)
-      headers.should.equal @test_headers
-      response.join.should.equal @test_body
+      headers.should eq(@test_headers)
+      response.join.should eq(@test_body)
     end
 
     context "when env['csshttprequest.chr']" do
@@ -43,20 +42,20 @@ begin
 
       specify "should modify the content length to the correct value" do
         headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
-        headers['Content-Length'].should.equal @encoded_body.length.to_s
+        headers['Content-Length'].should eq(@encoded_body.length.to_s)
       end
 
       specify "should modify the content type to the correct value" do
         headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
-        headers['Content-Type'].should.equal 'text/css'
+        headers['Content-Type'].should eq('text/css')
       end
 
       specify "should not modify any other headers" do
         headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
-        headers.should.equal @test_headers.merge({
+        headers.should eq(@test_headers.merge({
           'Content-Type' => 'text/css',
           'Content-Length' => @encoded_body.length.to_s
-        })
+        }))
       end
     end
 

--- a/test/spec_rack_deflect.rb
+++ b/test/spec_rack_deflect.rb
@@ -1,10 +1,9 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/deflect'
 
-context "Rack::Deflect" do
+describe "Rack::Deflect" do
 
-  setup do
+  before do
     @app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ['cookies']] }
     @mock_addr_1 = '111.111.111.111'
     @mock_addr_2 = '222.222.222.222'
@@ -22,8 +21,8 @@ context "Rack::Deflect" do
   specify "should allow regular requests to follow through" do
     app = mock_deflect
     status, headers, body = app.call mock_env(@mock_addr_1)
-    status.should.equal 200
-    body.should.equal ['cookies']
+    status.should eq(200)
+    body.should eq(['cookies'])
   end
 
   specify "should deflect requests exceeding the request threshold" do
@@ -34,19 +33,19 @@ context "Rack::Deflect" do
     # First 5 should be fine
     5.times do
       status, headers, body = app.call env
-      status.should.equal 200
-      body.should.equal ['cookies']
+      status.should eq(200)
+      body.should eq(['cookies'])
     end
 
     # Remaining requests should fail for 10 seconds
     10.times do
       status, headers, body = app.call env
-      status.should.equal 403
-      body.should.equal []
+      status.should eq(403)
+      body.should eq([])
     end
 
     # Log should reflect that we have blocked an address
-    log.string.should.match(/^deflect\(\d+\/\d+\/\d+\): blocked 111.111.111.111\n/)
+    log.string.should match(/^deflect\(\d+\/\d+\/\d+\): blocked 111.111.111.111\n/)
   end
 
   specify "should expire blocking" do
@@ -57,14 +56,14 @@ context "Rack::Deflect" do
     # First 5 should be fine
     5.times do
       status, headers, body = app.call env
-      status.should.equal 200
-      body.should.equal ['cookies']
+      status.should eq(200)
+      body.should eq(['cookies'])
     end
 
     # Exceeds request threshold
     status, headers, body = app.call env
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
 
     # Allow block to expire
     sleep 3
@@ -72,12 +71,12 @@ context "Rack::Deflect" do
     # Another 5 is fine now
     5.times do
       status, headers, body = app.call env
-      status.should.equal 200
-      body.should.equal ['cookies']
+      status.should eq(200)
+      body.should eq(['cookies'])
     end
 
     # Log should reflect block and release
-    log.string.should.match(/deflect.*: blocked 111\.111\.111\.111\ndeflect.*: released 111\.111\.111\.111\n/)
+    log.string.should match(/deflect.*: blocked 111\.111\.111\.111\ndeflect.*: released 111\.111\.111\.111\n/)
   end
 
   specify "should allow whitelisting of remote addresses" do
@@ -87,8 +86,8 @@ context "Rack::Deflect" do
     # Whitelisted addresses are always fine
     10.times do
       status, headers, body = app.call env
-      status.should.equal 200
-      body.should.equal ['cookies']
+      status.should eq(200)
+      body.should eq(['cookies'])
     end
   end
 
@@ -96,12 +95,12 @@ context "Rack::Deflect" do
     app = mock_deflect :blacklist => [@mock_addr_2]
 
     status, headers, body = app.call mock_env(@mock_addr_1)
-    status.should.equal 200
-    body.should.equal ['cookies']
+    status.should eq(200)
+    body.should eq(['cookies'])
 
     status, headers, body = app.call mock_env(@mock_addr_2)
-    status.should.equal 403
-    body.should.equal []
+    status.should eq(403)
+    body.should eq([])
   end
 
 end

--- a/test/spec_rack_evil.rb
+++ b/test/spec_rack_evil.rb
@@ -1,9 +1,8 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/evil'
 require 'erb'
 
-context "Rack::Evil" do
+describe "Rack::Evil" do
   app = lambda do |env|
     template = ERB.new("<%= throw :response, [404, {'Content-Type' => 'text/html'}, 'Never know where it comes from'] %>")
     [200, {'Content-Type' => 'text/plain'}, template.result(binding)]
@@ -12,8 +11,8 @@ context "Rack::Evil" do
   specify "should enable the app to return the response from anywhere" do
     status, headers, body = Rack::Evil.new(app).call({})
 
-    status.should.equal 404
-    headers['Content-Type'].should.equal 'text/html'
-    body.should.equal 'Never know where it comes from'
+    status.should eq(404)
+    headers['Content-Type'].should eq('text/html')
+    body.should eq('Never know where it comes from')
   end
 end

--- a/test/spec_rack_expectation_cascade.rb
+++ b/test/spec_rack_expectation_cascade.rb
@@ -1,22 +1,21 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/expectation_cascade'
 
-context "Rack::ExpectationCascade" do
+describe "Rack::ExpectationCascade" do
   specify "with no apps returns a 404 if no expectation header was set" do
     app = Rack::ExpectationCascade.new
     env = {}
     response = app.call(env)
-    response[0].should.equal 404
-    env.should.equal({})
+    response[0].should eq(404)
+    env.should eq({})
   end
 
   specify "with no apps returns a 417 if expectation header was set" do
     app = Rack::ExpectationCascade.new
     env = {"Expect" => "100-continue"}
     response = app.call(env)
-    response[0].should.equal 417
-    env.should.equal({"Expect" => "100-continue"})
+    response[0].should eq(417)
+    env.should eq({"Expect" => "100-continue"})
   end
 
   specify "returns first successful response" do
@@ -25,8 +24,8 @@ context "Rack::ExpectationCascade" do
       cascade << lambda { |env| [200, {"Content-Type" => "text/plain"}, ["OK"]] }
     end
     response = app.call({})
-    response[0].should.equal 200
-    response[2][0].should.equal "OK"
+    response[0].should eq(200)
+    response[2][0].should eq("OK")
   end
 
   specify "expectation is set if it has not been already" do
@@ -34,8 +33,8 @@ context "Rack::ExpectationCascade" do
       cascade << lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Expect: #{env["Expect"]}"]] }
     end
     response = app.call({})
-    response[0].should.equal 200
-    response[2][0].should.equal "Expect: 100-continue"
+    response[0].should eq(200)
+    response[2][0].should eq("Expect: 100-continue")
   end
 
   specify "returns a 404 if no apps where matched and no expectation header was set" do
@@ -43,8 +42,8 @@ context "Rack::ExpectationCascade" do
       cascade << lambda { |env| [417, {"Content-Type" => "text/plain"}, []] }
     end
     response = app.call({})
-    response[0].should.equal 404
-    response[2][0].should.equal nil
+    response[0].should eq(404)
+    response[2][0].should eq(nil)
   end
 
   specify "returns a 417 if no apps where matched and a expectation header was set" do
@@ -52,8 +51,8 @@ context "Rack::ExpectationCascade" do
       cascade << lambda { |env| [417, {"Content-Type" => "text/plain"}, []] }
     end
     response = app.call({"Expect" => "100-continue"})
-    response[0].should.equal 417
-    response[2][0].should.equal nil
+    response[0].should eq(417)
+    response[2][0].should eq(nil)
   end
 
   specify "nests expectation cascades" do
@@ -66,7 +65,7 @@ context "Rack::ExpectationCascade" do
       end
     end
     response = app.call({})
-    response[0].should.equal 200
-    response[2][0].should.equal "OK"
+    response[0].should eq(200)
+    response[2][0].should eq("OK")
   end
 end

--- a/test/spec_rack_garbagecollector.rb
+++ b/test/spec_rack_garbagecollector.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/garbagecollector'
 
-context 'Rack::GarbageCollector' do
+describe 'Rack::GarbageCollector' do
 
   specify 'starts the garbage collector after each request' do
     app = lambda { |env|

--- a/test/spec_rack_host_meta.rb
+++ b/test/spec_rack_host_meta.rb
@@ -1,11 +1,10 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/host_meta'
 require 'rack/contrib/not_found'
 
-context "Rack::HostMeta" do
+describe "Rack::HostMeta" do
 
-  setup do
+  before do
     app = Rack::Builder.new do
       use Rack::Lint
       use Rack::ContentLength
@@ -20,31 +19,31 @@ context "Rack::HostMeta" do
   end
 
   specify "should respond to /host-meta" do
-    @response.status.should.equal 200
+    @response.status.should eq(200)
   end
 
   specify "should respond with the correct media type" do
-    @response['Content-Type'].should.equal 'application/host-meta'
+    @response['Content-Type'].should eq('application/host-meta')
   end
 
   specify "should include a Link entry for each Link item in the config block" do
-    @response.body.should.match(/Link:\s*<\/robots.txt>;.*\n/)
-    @response.body.should.match(/Link:\s*<\/w3c\/p3p.xml>;.*/)
+    @response.body.should match(/Link:\s*<\/robots.txt>;.*\n/)
+    @response.body.should match(/Link:\s*<\/w3c\/p3p.xml>;.*/)
   end
 
   specify "should include a Link-Pattern entry for each Link-Pattern item in the config" do
-    @response.body.should.match(/Link-Pattern:\s*<\{uri\};json_schema>;.*/)
+    @response.body.should match(/Link-Pattern:\s*<\{uri\};json_schema>;.*/)
   end
 
   specify "should include a rel attribute for each Link or Link-Pattern entry where specified" do
-    @response.body.should.match(/rel="robots"/)
-    @response.body.should.match(/rel="privacy"/)
-    @response.body.should.match(/rel="describedby"/)
+    @response.body.should match(/rel="robots"/)
+    @response.body.should match(/rel="privacy"/)
+    @response.body.should match(/rel="describedby"/)
   end
 
   specify "should include a type attribute for each Link or Link-Pattern entry where specified" do
-    @response.body.should.match(/Link:\s*<\/w3c\/p3p.xml>;.*type.*application\/p3p.xml/)
-    @response.body.should.match(/Link-Pattern:\s*<\{uri\};json_schema>;.*type.*application\/x-schema\+json/)
+    @response.body.should match(/Link:\s*<\/w3c\/p3p.xml>;.*type.*application\/p3p.xml/)
+    @response.body.should match(/Link-Pattern:\s*<\{uri\};json_schema>;.*type.*application\/x-schema\+json/)
   end
 
 end

--- a/test/spec_rack_jsonp.rb
+++ b/test/spec_rack_jsonp.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/jsonp'
 
-context "Rack::JSONP" do
+describe "Rack::JSONP" do
 
   context "when a callback parameter is provided" do
     specify "should wrap the response body in the Javascript callback if JSON" do
@@ -11,7 +10,7 @@ context "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       body = Rack::JSONP.new(app).call(request).last
-      body.should.equal ["#{callback}(#{test_body})"]
+      body.should eq(["#{callback}(#{test_body})"])
     end
     
     specify "should not wrap the response body in a callback if body is not JSON" do
@@ -20,7 +19,7 @@ context "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       body = Rack::JSONP.new(app).call(request).last
-      body.should.equal ['{"bar":"foo"}']
+      body.should eq(['{"bar":"foo"}'])
     end
     
     specify "should update content length if it was set" do
@@ -31,7 +30,7 @@ context "Rack::JSONP" do
 
       headers = Rack::JSONP.new(app).call(request)[1]
       expected_length = test_body.length + callback.length + "()".length
-      headers['Content-Length'].should.equal(expected_length.to_s)
+      headers['Content-Length'].should eq(expected_length.to_s)
     end
     
     specify "should not touch content length if not set" do
@@ -40,7 +39,7 @@ context "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       headers = Rack::JSONP.new(app).call(request)[1]
-      headers['Content-Length'].should.equal nil
+      headers['Content-Length'].should eq(nil)
     end
     
     specify "should modify the content type to application/javascript" do
@@ -49,7 +48,7 @@ context "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       headers = Rack::JSONP.new(app).call(request)[1]
-      headers['Content-Type'].should.equal('application/javascript')
+      headers['Content-Type'].should eq('application/javascript')
     end
 
     specify "should not allow literal U+2028 or U+2029" do
@@ -63,9 +62,9 @@ context "Rack::JSONP" do
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       body = Rack::JSONP.new(app).call(request).last
       unless "\u2028" == 'u2028'
-        body.join.should.not.match(/\u2028|\u2029/)
+        body.join.should_not match(/\u2028|\u2029/)
       else
-        body.join.should.not.match(/\342\200\250|\342\200\251/)
+        body.join.should_not match(/\342\200\250|\342\200\251/)
       end
     end
     
@@ -76,7 +75,7 @@ context "Rack::JSONP" do
         app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
         request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
         body = Rack::JSONP.new(app).call(request).last
-        body.should.equal ['{"bar":"foo"}']
+        body.should eq(['{"bar":"foo"}'])
       end
     end
     
@@ -89,7 +88,7 @@ context "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           body = Rack::JSONP.new(app).call(request).last
-          body.should.equal ['Bad Request']
+          body.should eq(['Bad Request'])
         end
 
         specify 'should return set the response code to 400' do
@@ -99,7 +98,7 @@ context "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           response_code = Rack::JSONP.new(app).call(request).first
-          response_code.should.equal 400
+          response_code.should eq(400)
         end
       end
 
@@ -111,7 +110,7 @@ context "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           body = Rack::JSONP.new(app).call(request).last
-          body.should.equal ['Good Request']
+          body.should eq(['Good Request'])
         end
 
         specify 'should not change the response code from 200' do
@@ -121,7 +120,7 @@ context "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           response_code = Rack::JSONP.new(app).call(request).first
-          response_code.should.equal 200
+          response_code.should eq(200)
         end
       end
     end
@@ -134,10 +133,10 @@ context "Rack::JSONP" do
       end
       
       def assert_bad_request(response)
-        response.should.not.equal nil
+        response.should_not be_nil
         status, headers, body = response
-        status.should.equal 400
-        body.should.equal ["Bad Request"]
+        status.should eq(400)
+        body.should eq(["Bad Request"])
       end
       
       specify "should return bad request for callback with invalid characters" do
@@ -154,8 +153,8 @@ context "Rack::JSONP" do
       
       specify "should not return a bad request for callbacks with dots in the callback" do
         status, headers, body = request(callback = "foo.bar.baz", test_body = '{"foo":"bar"}')
-        status.should.equal 200
-        body.should.equal ["#{callback}(#{test_body})"]
+        status.should eq(200)
+        body.should eq(["#{callback}(#{test_body})"])
       end
     end
     
@@ -166,7 +165,7 @@ context "Rack::JSONP" do
     app = lambda { |env| [200, {'Content-Type' => 'application/json'}, test_body] }
     request = Rack::MockRequest.env_for("/", :params => "foo=bar")
     body = Rack::JSONP.new(app).call(request).last
-    body.should.equal test_body
+    body.should eq(test_body)
   end
 
   specify "should not change anything if it's not a json response" do
@@ -174,7 +173,7 @@ context "Rack::JSONP" do
     app = lambda { |env| [404, {'Content-Type' => 'text/html'}, [test_body]] }
     request = Rack::MockRequest.env_for("/", :params => "callback=foo", 'HTTP_ACCEPT' => 'application/json')
     body = Rack::JSONP.new(app).call(request).last
-    body.should.equal [test_body]
+    body.should eq([test_body])
   end
   
   specify "should not change anything if there is no Content-Type header" do
@@ -182,7 +181,7 @@ context "Rack::JSONP" do
     app = lambda { |env| [404, {}, [test_body]] }
     request = Rack::MockRequest.env_for("/", :params => "callback=foo", 'HTTP_ACCEPT' => 'application/json')
     body = Rack::JSONP.new(app).call(request).last
-    body.should.equal [test_body]
+    body.should eq([test_body])
   end  
 
 end

--- a/test/spec_rack_lighttpd_script_name_fix.rb
+++ b/test/spec_rack_lighttpd_script_name_fix.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/lighttpd_script_name_fix'
 
-context "Rack::LighttpdScriptNameFix" do
+describe "Rack::LighttpdScriptNameFix" do
   specify "corrects SCRIPT_NAME and PATH_INFO set by lighttpd " do
     env = {
       "PATH_INFO" => "/foo/bar/baz",
@@ -10,7 +9,7 @@ context "Rack::LighttpdScriptNameFix" do
     }
     app = lambda { |_| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     response = Rack::LighttpdScriptNameFix.new(app).call(env)
-    env['SCRIPT_NAME'].should.be.empty
-    env['PATH_INFO'].should.equal '/hello/foo/bar/baz'
+    env['SCRIPT_NAME'].should be_empty
+    env['PATH_INFO'].should eq('/hello/foo/bar/baz')
   end
 end

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -1,9 +1,8 @@
-require 'test/spec'
 require 'rack/mock'
 
-context "Rack::Locale" do
+describe "Rack::Locale" do
 
-  setup do
+  before do
     begin
       require 'rack/contrib/locale'
     rescue LoadError
@@ -24,34 +23,34 @@ context "Rack::Locale" do
 
   specify 'should use I18n.default_locale if no languages are requested' do
     I18n.default_locale = :zh
-    response_with_languages(nil).body.should.equal('zh')
+    response_with_languages(nil).body.should eq('zh')
   end
 
   specify 'should treat an empty qvalue as 1.0' do
-    response_with_languages('en,es;q=0.95').body.should.equal('en')
+    response_with_languages('en,es;q=0.95').body.should eq('en')
   end
 
   specify 'should set the Content-Language response header' do
     headers = response_with_languages('de;q=0.7,dk;q=0.9').headers
-    headers['Content-Language'].should.equal('dk')
+    headers['Content-Language'].should eq('dk')
   end
 
   specify 'should pick the language with the highest qvalue' do
-    response_with_languages('en;q=0.9,es;q=0.95').body.should.equal('es')
+    response_with_languages('en;q=0.9,es;q=0.95').body.should eq('es')
   end
 
   specify 'should retain full language codes' do
-    response_with_languages('en-gb,en-us;q=0.95;en').body.should.equal('en-gb')
+    response_with_languages('en-gb,en-us;q=0.95;en').body.should eq('en-gb')
   end
 
   specify 'should treat a * as "all other languages"' do
-    response_with_languages('*,en;q=0.5').body.should.equal( I18n.default_locale.to_s )
+    response_with_languages('*,en;q=0.5').body.should eq(I18n.default_locale.to_s )
   end
 
   specify 'should reset the I18n locale after the response' do
     I18n.locale = 'es'
     response_with_languages('en,de;q=0.8')
-    I18n.locale.should.equal(:es)
+    I18n.locale.should eq(:es)
   end
 
 end

--- a/test/spec_rack_mailexceptions.rb
+++ b/test/spec_rack_mailexceptions.rb
@@ -1,4 +1,3 @@
-require 'test/spec'
 require 'rack/mock'
 
 begin
@@ -14,9 +13,9 @@ begin
     return boom
   end
 
-  context 'Rack::MailExceptions' do
+  describe 'Rack::MailExceptions' do
 
-    setup do
+    before do
       @app = lambda { |env| raise TestError, 'Why, I say' }
       @env = Rack::MockRequest.env_for("/foo",
         'FOO' => 'BAR',
@@ -43,7 +42,7 @@ begin
           mail.subject '[ERROR] %s'
           mail.smtp @smtp_settings
         end
-      called.should.be == true
+      called.should == true
     end
 
     specify 'generates a TMail object with configured settings' do
@@ -56,12 +55,12 @@ begin
         end
 
       mail = mailer.send(:generate_mail, test_exception, @env)
-      mail.to.should.equal ['foo@example.org']
-      mail.from.should.equal ['bar@example.org']
-      mail.subject.should.equal '[ERROR] Suffering Succotash!'
-      mail.body.should.not.be.nil
-      mail.body.should.be =~ /FOO:\s+"BAR"/
-      mail.body.should.be =~ /^\s*THE BODY\s*$/
+      mail.to.should eq(['foo@example.org'])
+      mail.from.should eq(['bar@example.org'])
+      mail.subject.should eq('[ERROR] Suffering Succotash!')
+      mail.body.should_not be_nil
+      mail.body.should =~ /FOO:\s+"BAR"/
+      mail.body.should =~ /^\s*THE BODY\s*$/
     end
 
     specify 'catches exceptions raised from app, sends mail, and re-raises' do
@@ -72,8 +71,8 @@ begin
           mail.subject '[ERROR] %s'
           mail.smtp @smtp_settings
         end
-      lambda { mailer.call(@env) }.should.raise(TestError)
-      @env['mail.sent'].should.be == true
+      lambda { mailer.call(@env) }.should raise_exception(TestError)
+      @env['mail.sent'].should == true
     end
 
     if TEST_SMTP && ! TEST_SMTP.empty?
@@ -82,15 +81,15 @@ begin
           Rack::MailExceptions.new(@app) do |mail|
             mail.config.merge! TEST_SMTP
           end
-        lambda { mailer.call(@env) }.should.raise(TestError)
-        @env['mail.sent'].should.be == true
+        lambda { mailer.call(@env) }.should raise_exception(TestError)
+        @env['mail.sent'].should == true
       end
     else
       STDERR.puts 'WARN: Skipping SMTP tests (edit test/mail_settings.rb to enable)'
     end
 
     context 'for tls enabled smtp' do
-      setup do
+      before do
         @smtp_settings.merge!(TEST_SMTP_TLS)
         @mailer = 
           Rack::MailExceptions.new(@app) do |mail|
@@ -104,16 +103,16 @@ begin
       describe 'with :enable_starttls_auto set to :auto' do
         specify 'sends mail' do
           @mailer.smtp.merge(:enable_starttls_auto => :auto)
-          lambda { @mailer.call(@env) }.should.raise(TestError)
-          @env['mail.sent'].should.be true
+          lambda { @mailer.call(@env) }.should raise_exception(TestError)
+          @env['mail.sent'].should ==  true
         end
       end
 
       describe 'with :enable_starttls_auto set to true' do
         specify 'sends mail' do
           @mailer.smtp.merge(:enable_starttls_auto => true)
-          lambda { @mailer.call(@env) }.should.raise(TestError)
-          @env['mail.sent'].should.be true
+          lambda { @mailer.call(@env) }.should raise_exception(TestError)
+          @env['mail.sent'].should ==  true
         end
       end
     end if defined?(TEST_SMTP_TLS)
@@ -128,7 +127,7 @@ begin
         def self.tls; @@_tls; end
       end
 
-      setup do
+      before do
         Rack::MailExceptions.class_eval { def service; FakeSMTP; end}
         @mailer = 
           Rack::MailExceptions.new(@app) do |mail|
@@ -142,15 +141,15 @@ begin
       context 'with :enable_starttls_auto unset' do
         specify 'sends mail' do
           @mailer.smtp[:enable_starttls_auto] = nil
-          lambda { @mailer.call(@env) }.should.raise(TestError)
-          FakeSMTP.tls.should.be nil
+          lambda { @mailer.call(@env) }.should raise_exception(TestError)
+          FakeSMTP.tls.should be_nil
         end
       end
 
       context 'with :enable_starttls_auto set to true' do
         specify 'sends mail' do
           @mailer.smtp[:enable_starttls_auto] = true
-          lambda { @mailer.call(@env) }.should.raise(TestError)
+          lambda { @mailer.call(@env) }.should raise_exception(TestError)
           FakeSMTP.tls.should == true
         end
       end
@@ -158,7 +157,7 @@ begin
       context 'with :enable_starttls_auto set to :auto' do
         specify 'sends mail' do
           @mailer.smtp[:enable_starttls_auto] = :auto
-          lambda { @mailer.call(@env) }.should.raise(TestError)
+          lambda { @mailer.call(@env) }.should raise_exception(TestError)
           FakeSMTP.tls.should == :auto
         end
       end

--- a/test/spec_rack_nested_params.rb
+++ b/test/spec_rack_nested_params.rb
@@ -1,9 +1,8 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/nested_params'
 require 'rack/methodoverride'
 
-context Rack::NestedParams do
+describe Rack::NestedParams do
 
   App = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env)] }
 
@@ -22,25 +21,25 @@ context Rack::NestedParams do
 
   specify "should handle requests with POST body Content-Type of application/x-www-form-urlencoded" do
     req = middleware.call(form_post({'foo[bar][baz]' => 'nested'})).last
-    req.POST.should.equal({"foo" => { "bar" => { "baz" => "nested" }}})
+    req.POST.should eq({"foo" => { "bar" => { "baz" => "nested" }}})
   end
 
   specify "should not parse requests with other Content-Type" do
     req = middleware.call(form_post({'foo[bar][baz]' => 'nested'}, 'text/plain')).last
-    req.POST.should.equal({})
+    req.POST.should eq({})
   end
 
   specify "should work even after another middleware already parsed the request" do
     app = Rack::MethodOverride.new(middleware)
     req = app.call(form_post({'_method' => 'put', 'foo[bar]' => 'nested'})).last
-    req.POST.should.equal({'_method' => 'put', "foo" => { "bar" => "nested" }})
-    req.put?.should.equal true
+    req.POST.should eq({'_method' => 'put', "foo" => { "bar" => "nested" }})
+    req.put?.should eq(true)
   end
 
   specify "should make first boolean have precedence even after request already parsed" do
     app = Rack::MethodOverride.new(middleware)
     req = app.call(form_post("foo=1&foo=0")).last
-    req.POST.should.equal({"foo" => '1'})
+    req.POST.should eq({"foo" => '1'})
   end
 
 end

--- a/test/spec_rack_not_found.rb
+++ b/test/spec_rack_not_found.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/not_found'
 
-context "Rack::NotFound" do
+describe "Rack::NotFound" do
 
   specify "should render the file at the given path for all requests" do
     app = Rack::Builder.new do
@@ -10,8 +9,8 @@ context "Rack::NotFound" do
       run Rack::NotFound.new('test/404.html')
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.should.equal('Not Found')
-    response.status.should.equal(404)
+    response.body.should eq('Not Found')
+    response.status.should eq(404)
   end
 
 end

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -1,29 +1,28 @@
-require 'test/spec'
 require 'rack/mock'
 
 begin
   require 'rack/contrib/post_body_content_type_parser'
 
-  context "Rack::PostBodyContentTypeParser" do
+  describe "Rack::PostBodyContentTypeParser" do
 
     specify "should parse 'application/json' requests" do
       params = params_for_request '{"key":"value"}', "application/json"
-      params['key'].should.equal "value"
+      params['key'].should eq("value")
     end
 
     specify "should parse 'application/json; charset=utf-8' requests" do
       params = params_for_request '{"key":"value"}', "application/json; charset=utf-8"
-      params['key'].should.equal "value"
+      params['key'].should eq("value")
     end
     
     specify "should parse 'application/json' requests with empty body" do
       params = params_for_request "", "application/json"
-      params.should.equal({})
+      params.should eq({})
     end
 
     specify "shouldn't affect form-urlencoded requests" do
       params = params_for_request("key=value", "application/x-www-form-urlencoded")
-      params['key'].should.equal "value"
+      params['key'].should eq("value")
     end
 
   end

--- a/test/spec_rack_proctitle.rb
+++ b/test/spec_rack_proctitle.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/proctitle'
 
-context "Rack::ProcTitle" do
+describe "Rack::ProcTitle" do
   F = ::File
 
   progname = File.basename($0)
@@ -14,13 +13,13 @@ context "Rack::ProcTitle" do
 
   specify "should set the process title when created" do
     Rack::ProcTitle.new(simple_app)
-    $0.should.equal "#{progname} [#{appname}] init ..."
+    $0.should eq("#{progname} [#{appname}] init ...")
   end
 
   specify "should set the process title on each request" do
     app = Rack::ProcTitle.new(simple_app)
     req = Rack::MockRequest.new(app)
     10.times { req.get('/hello') }
-    $0.should.equal "#{progname} [#{appname}/80] (10) GET /hello"
+    $0.should eq("#{progname} [#{appname}/80] (10) GET /hello")
   end
 end

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -1,39 +1,38 @@
-require 'test/spec'
 require 'rack/mock'
 
 begin
   require 'rack/contrib/profiler'
 
-  context 'Rack::Profiler' do
+  describe 'Rack::Profiler' do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, 'Oh hai der'] }
     request = Rack::MockRequest.env_for("/", :params => "profile=process_time")
 
     specify 'printer defaults to RubyProf::CallStackPrinter' do
       profiler = Rack::Profiler.new(nil)
-      profiler.instance_variable_get('@printer').should.equal RubyProf::CallStackPrinter
-      profiler.instance_variable_get('@times').should.equal 1
+      profiler.instance_variable_get('@printer').should eq(RubyProf::CallStackPrinter)
+      profiler.instance_variable_get('@times').should eq(1)
     end
 
     specify 'CallStackPrinter has Content-Type test/html' do
       headers = Rack::Profiler.new(app, :printer => :call_stack).call(request)[1]
-      headers.should.equal "Content-Type"=>"text/html"
+      headers.should eq("Content-Type"=>"text/html")
     end
 
     specify 'CallTreePrinter has correct headers' do
       headers = Rack::Profiler.new(app, :printer => :call_tree).call(request)[1]
-      headers.should.equal "Content-Disposition"=>"attachment; filename=\"/.process_time.tree\"", "Content-Type"=>"application/octet-stream"
+      headers.should eq("Content-Disposition"=>"attachment; filename=\"/.process_time.tree\"", "Content-Type"=>"application/octet-stream")
     end
 
     specify 'FlatPrinter and GraphPrinter has Content-Type text/plain' do
       %w(flat graph).each do |printer|
         headers = Rack::Profiler.new(app, :printer => printer.to_sym).call(request)[1]
-        headers.should.equal "Content-Type"=>"text/plain"
+        headers.should eq("Content-Type"=>"text/plain")
       end
     end
 
     specify 'GraphHtmlPrinter has Content-Type text/html' do
       headers = Rack::Profiler.new(app, :printer => :graph_html).call(request)[1]
-      headers.should.equal "Content-Type"=>"text/html"
+      headers.should eq("Content-Type"=>"text/html")
     end
   end
 

--- a/test/spec_rack_relative_redirect.rb
+++ b/test/spec_rack_relative_redirect.rb
@@ -1,16 +1,15 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/relative_redirect'
 require 'fileutils'
 
-context Rack::RelativeRedirect do
+describe Rack::RelativeRedirect do
   def request(opts={}, &block)
     @def_status = opts[:status] if opts[:status]
     @def_location = opts[:location] if opts[:location]
     yield Rack::MockRequest.new(Rack::RelativeRedirect.new(@def_app, &opts[:block])).get(opts[:path]||@def_path, opts[:headers]||{})
   end
 
-  setup do
+  before do
     @def_path = '/path/to/blah'
     @def_status = 301
     @def_location = '/redirect/to/blah'
@@ -19,34 +18,34 @@ context Rack::RelativeRedirect do
 
   specify "should make the location url an absolute url if currently a relative url" do
     request do |r|
-      r.status.should.equal(301)
-      r.headers['Location'].should.equal('http://example.org/redirect/to/blah')
+      r.status.should eq(301)
+      r.headers['Location'].should eq('http://example.org/redirect/to/blah')
     end
     request(:status=>302, :location=>'/redirect') do |r|
-      r.status.should.equal(302)
-      r.headers['Location'].should.equal('http://example.org/redirect')
+      r.status.should eq(302)
+      r.headers['Location'].should eq('http://example.org/redirect')
     end
   end
 
   specify "should use the request path if the relative url is given and doesn't start with a slash" do
     request(:status=>303, :location=>'redirect/to/blah') do |r|
-      r.status.should.equal(303)
-      r.headers['Location'].should.equal('http://example.org/path/to/redirect/to/blah')
+      r.status.should eq(303)
+      r.headers['Location'].should eq('http://example.org/path/to/redirect/to/blah')
     end
     request(:status=>303, :location=>'redirect') do |r|
-      r.status.should.equal(303)
-      r.headers['Location'].should.equal('http://example.org/path/to/redirect')
+      r.status.should eq(303)
+      r.headers['Location'].should eq('http://example.org/path/to/redirect')
     end
   end
 
   specify "should use a given block to make the url absolute" do
     request(:block=>proc{|env, res| "https://example.org"}) do |r|
-      r.status.should.equal(301)
-      r.headers['Location'].should.equal('https://example.org/redirect/to/blah')
+      r.status.should eq(301)
+      r.headers['Location'].should eq('https://example.org/redirect/to/blah')
     end
     request(:status=>303, :location=>'/redirect', :block=>proc{|env, res| "https://e.org:9999/blah"}) do |r|
-      r.status.should.equal(303)
-      r.headers['Location'].should.equal('https://e.org:9999/blah/redirect')
+      r.status.should eq(303)
+      r.headers['Location'].should eq('https://e.org:9999/blah/redirect')
     end
   end
 
@@ -54,25 +53,25 @@ context Rack::RelativeRedirect do
     status = 200
     @def_app = lambda { |env| [status, {'Content-Type' => "text/html"}, [""]]}
     request do |r|
-      r.status.should.equal(200)
-      r.headers.should.not.include?('Location')
+      r.status.should eq(200)
+      r.headers.should_not include('Location')
     end
     status = 404
     @def_app = lambda { |env| [status, {'Content-Type' => "text/html", 'Location' => 'redirect'}, [""]]}
     request do |r|
-      r.status.should.equal(404)
-      r.headers['Location'].should.equal('redirect')
+      r.status.should eq(404)
+      r.headers['Location'].should eq('redirect')
     end
   end
 
   specify "should not modify the location url if it is already an absolute url" do
     request(:location=>'https://example.org/') do |r|
-      r.status.should.equal(301)
-      r.headers['Location'].should.equal('https://example.org/')
+      r.status.should eq(301)
+      r.headers['Location'].should eq('https://example.org/')
     end
     request(:status=>302, :location=>'https://e.org:9999/redirect') do |r|
-      r.status.should.equal(302)
-      r.headers['Location'].should.equal('https://e.org:9999/redirect')
+      r.status.should eq(302)
+      r.headers['Location'].should eq('https://e.org:9999/redirect')
     end
   end
 end

--- a/test/spec_rack_response_cache.rb
+++ b/test/spec_rack_response_cache.rb
@@ -1,137 +1,134 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/response_cache'
 require 'fileutils'
 
-context Rack::ResponseCache do
-  F = ::File
-
+describe Rack::ResponseCache do
   def request(opts={}, &block)
     Rack::MockRequest.new(Rack::ResponseCache.new(block||@def_app, opts[:cache]||@cache, &opts[:rc_block])).send(opts[:meth]||:get, opts[:path]||@def_path, opts[:headers]||{})
   end
 
-  setup do
+  before do
     @cache = {}
-    @def_disk_cache = F.join(F.dirname(__FILE__), 'response_cache_test_disk_cache')
+    @def_disk_cache = ::File.join(::File.dirname(__FILE__), 'response_cache_test_disk_cache')
     @def_value = ["rack-response-cache"]
     @def_path = '/path/to/blah'
     @def_app = lambda { |env| [200, {'Content-Type' => env['CT'] || 'text/html'}, @def_value]}
   end
-  teardown do
+  after do
     FileUtils.rm_rf(@def_disk_cache)
   end
 
   specify "should cache results to disk if cache is a string" do
     request(:cache=>@def_disk_cache)
-    F.read(F.join(@def_disk_cache, 'path', 'to', 'blah.html')).should.equal @def_value.first
+    ::File.read(::File.join(@def_disk_cache, 'path', 'to', 'blah.html')).should eq( @def_value.first)
     request(:path=>'/path/3', :cache=>@def_disk_cache)
-    F.read(F.join(@def_disk_cache, 'path', '3.html')).should.equal @def_value.first
+    ::File.read(::File.join(@def_disk_cache, 'path', '3.html')).should eq( @def_value.first)
   end
 
   specify "should cache results to given cache if cache is not a string" do
     request
-    @cache.should.equal('/path/to/blah.html'=>@def_value)
+    @cache.should eq('/path/to/blah.html'=>@def_value)
     request(:path=>'/path/3')
-    @cache.should.equal('/path/to/blah.html'=>@def_value, '/path/3.html'=>@def_value)
+    @cache.should eq('/path/to/blah.html'=>@def_value, '/path/3.html'=>@def_value)
   end
 
   specify "should not CACHE RESults if request method is not GET" do
     request(:meth=>:post)
-    @cache.should.equal({})
+    @cache.should eq({})
     request(:meth=>:put)
-    @cache.should.equal({})
+    @cache.should eq({})
     request(:meth=>:delete)
-    @cache.should.equal({})
+    @cache.should eq({})
   end
 
   specify "should not cache results if there is a query string" do
     request(:path=>'/path/to/blah?id=1')
-    @cache.should.equal({})
+    @cache.should eq({})
     request(:path=>'/path/to/?id=1')
-    @cache.should.equal({})
+    @cache.should eq({})
     request(:path=>'/?id=1')
-    @cache.should.equal({})
+    @cache.should eq({})
   end
 
   specify "should cache results if there is an empty query string" do
     request(:path=>'/?')
-    @cache.should.equal('/index.html'=>@def_value)
+    @cache.should eq('/index.html'=>@def_value)
   end
 
   specify "should not cache results if the request is not sucessful (status 200)" do
     request{|env| [404, {'Content-Type' => 'text/html'}, ['']]}
-    @cache.should.equal({})
+    @cache.should eq({})
     request{|env| [500, {'Content-Type' => 'text/html'}, ['']]}
-    @cache.should.equal({})
+    @cache.should eq({})
     request{|env| [302, {'Content-Type' => 'text/html'}, ['']]}
-    @cache.should.equal({})
+    @cache.should eq({})
   end
 
   specify "should not cache results if the block returns nil or false" do
     request(:rc_block=>proc{false})
-    @cache.should.equal({})
+    @cache.should eq({})
     request(:rc_block=>proc{nil})
-    @cache.should.equal({})
+    @cache.should eq({})
   end
 
   specify "should cache results to path returned by block" do
     request(:rc_block=>proc{"1"})
-    @cache.should.equal("1"=>@def_value)
+    @cache.should eq("1"=>@def_value)
     request(:rc_block=>proc{"2"})
-    @cache.should.equal("1"=>@def_value, "2"=>@def_value)
+    @cache.should eq("1"=>@def_value, "2"=>@def_value)
   end
 
   specify "should pass the environment and response to the block" do
     e, r = nil, nil
     request(:rc_block=>proc{|env,res| e, r = env, res; nil})
-    e['PATH_INFO'].should.equal @def_path
-    e['REQUEST_METHOD'].should.equal 'GET'
-    e['QUERY_STRING'].should.equal ''
-    r.should.equal([200, {"Content-Type"=>"text/html"}, ["rack-response-cache"]])
+    e['PATH_INFO'].should eq( @def_path)
+    e['REQUEST_METHOD'].should eq( 'GET')
+    e['QUERY_STRING'].should eq( '')
+    r.should eq([200, {"Content-Type"=>"text/html"}, ["rack-response-cache"]])
   end
 
   specify "should unescape the path by default" do
     request(:path=>'/path%20with%20spaces')
-    @cache.should.equal('/path with spaces.html'=>@def_value)
+    @cache.should eq('/path with spaces.html'=>@def_value)
     request(:path=>'/path%3chref%3e')
-    @cache.should.equal('/path with spaces.html'=>@def_value, '/path<href>.html'=>@def_value)
+    @cache.should eq('/path with spaces.html'=>@def_value, '/path<href>.html'=>@def_value)
   end
 
   specify "should cache html, css, and xml responses by default" do
     request(:path=>'/a')
-    @cache.should.equal('/a.html'=>@def_value)
+    @cache.should eq('/a.html'=>@def_value)
     request(:path=>'/b', :headers=>{'CT'=>'text/xml'})
-    @cache.should.equal('/a.html'=>@def_value, '/b.xml'=>@def_value)
+    @cache.should eq('/a.html'=>@def_value, '/b.xml'=>@def_value)
     request(:path=>'/c', :headers=>{'CT'=>'text/css'})
-    @cache.should.equal('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
+    @cache.should eq('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
   end
 
   specify "should cache responses by default with the extension added if not already present" do
     request(:path=>'/a.html')
-    @cache.should.equal('/a.html'=>@def_value)
+    @cache.should eq('/a.html'=>@def_value)
     request(:path=>'/b.xml', :headers=>{'CT'=>'text/xml'})
-    @cache.should.equal('/a.html'=>@def_value, '/b.xml'=>@def_value)
+    @cache.should eq('/a.html'=>@def_value, '/b.xml'=>@def_value)
     request(:path=>'/c.css', :headers=>{'CT'=>'text/css'})
-    @cache.should.equal('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
+    @cache.should eq('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
   end
 
   specify "should not delete existing extensions" do
     request(:path=>'/d.css', :headers=>{'CT'=>'text/html'})
-    @cache.should.equal('/d.css.html'=>@def_value)
+    @cache.should eq('/d.css.html'=>@def_value)
   end
 
   specify "should cache html responses with empty basename to index.html by default" do
     request(:path=>'/')
-    @cache.should.equal('/index.html'=>@def_value)
+    @cache.should eq('/index.html'=>@def_value)
     request(:path=>'/blah/')
-    @cache.should.equal('/index.html'=>@def_value, '/blah/index.html'=>@def_value)
+    @cache.should eq('/index.html'=>@def_value, '/blah/index.html'=>@def_value)
     request(:path=>'/blah/2/')
-    @cache.should.equal('/index.html'=>@def_value, '/blah/index.html'=>@def_value, '/blah/2/index.html'=>@def_value)
+    @cache.should eq('/index.html'=>@def_value, '/blah/index.html'=>@def_value, '/blah/2/index.html'=>@def_value)
   end
 
   specify "should raise an error if a cache argument is not provided" do
     app = Rack::Builder.new{use Rack::ResponseCache; run lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST]}}
-    proc{Rack::MockRequest.new(app).get('/')}.should.raise(ArgumentError)
+    proc{Rack::MockRequest.new(app).get('/')}.should raise_exception(ArgumentError)
   end
 
 end

--- a/test/spec_rack_response_headers.rb
+++ b/test/spec_rack_response_headers.rb
@@ -1,14 +1,13 @@
-require 'test/spec'
 require 'rack'
 require 'rack/contrib/response_headers'
 
-context "Rack::ResponseHeaders" do
+describe "Rack::ResponseHeaders" do
 
   specify "yields a HeaderHash of response headers" do
     orig_headers = {'X-Foo' => 'foo', 'X-Bar' => 'bar'}
     app = Proc.new {[200, orig_headers, []]}
     middleware = Rack::ResponseHeaders.new(app) do |headers|
-      assert_instance_of Rack::Utils::HeaderHash, headers
+      headers.should be_instance_of Rack::Utils::HeaderHash
       orig_headers.should == headers
     end
     middleware.call({})

--- a/test/spec_rack_runtime.rb
+++ b/test/spec_rack_runtime.rb
@@ -1,8 +1,7 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/runtime'
 
-context "Rack::Runtime" do
+describe "Rack::Runtime" do
   specify "sets X-Runtime is none is set" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, "Hello, World!"] }
     response = Rack::Runtime.new(app).call({})

--- a/test/spec_rack_sendfile.rb
+++ b/test/spec_rack_sendfile.rb
@@ -1,14 +1,13 @@
-require 'test/spec'
 require 'rack/mock'
 require 'rack/contrib/sendfile'
 
-context "Rack::File" do
+describe "Rack::File" do
   specify "should respond to #to_path" do
-    Rack::File.new(Dir.pwd).should.respond_to :to_path
+    Rack::File.new(Dir.pwd).should respond_to :to_path
   end
 end
 
-context "Rack::Sendfile" do
+describe "Rack::Sendfile" do
   def sendfile_body
     res = ['Hello World']
     def res.to_path ; "/tmp/hello.txt" ; end
@@ -23,7 +22,7 @@ context "Rack::Sendfile" do
     Rack::Sendfile.new(simple_app(body))
   end
 
-  setup do
+  before do
     @request = Rack::MockRequest.new(sendfile_app)
   end
 
@@ -33,25 +32,25 @@ context "Rack::Sendfile" do
 
   specify "does nothing when no X-Sendfile-Type header present" do
     request do |response|
-      response.should.be.ok
-      response.body.should.equal 'Hello World'
-      response.headers.should.not.include 'X-Sendfile'
+      response.should be_ok
+      response.body.should eq('Hello World')
+      response.headers.should_not include 'X-Sendfile'
     end
   end
 
   specify "sets X-Sendfile response header and discards body" do
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Sendfile' do |response|
-      response.should.be.ok
-      response.body.should.be.empty
-      response.headers['X-Sendfile'].should.equal '/tmp/hello.txt'
+      response.should be_ok
+      response.body.should be_empty
+      response.headers['X-Sendfile'].should eq('/tmp/hello.txt')
     end
   end
 
   specify "sets X-Lighttpd-Send-File response header and discards body" do
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Lighttpd-Send-File' do |response|
-      response.should.be.ok
-      response.body.should.be.empty
-      response.headers['X-Lighttpd-Send-File'].should.equal '/tmp/hello.txt'
+      response.should be_ok
+      response.body.should be_empty
+      response.headers['X-Lighttpd-Send-File'].should eq('/tmp/hello.txt')
     end
   end
 
@@ -61,26 +60,26 @@ context "Rack::Sendfile" do
       'HTTP_X_ACCEL_MAPPING' => '/tmp/=/foo/bar/'
     }
     request headers do |response|
-      response.should.be.ok
-      response.body.should.be.empty
-      response.headers['X-Accel-Redirect'].should.equal '/foo/bar/hello.txt'
+      response.should be_ok
+      response.body.should be_empty
+      response.headers['X-Accel-Redirect'].should eq('/foo/bar/hello.txt')
     end
   end
 
   specify 'writes to rack.error when no X-Accel-Mapping is specified' do
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect' do |response|
-      response.should.be.ok
-      response.body.should.equal 'Hello World'
-      response.headers.should.not.include 'X-Accel-Redirect'
-      response.errors.should.include 'X-Accel-Mapping'
+      response.should be_ok
+      response.body.should eq('Hello World')
+      response.headers.should_not include 'X-Accel-Redirect'
+      response.errors.should include 'X-Accel-Mapping'
     end
   end
 
   specify 'does nothing when body does not respond to #to_path' do
     @request = Rack::MockRequest.new(sendfile_app(['Not a file...']))
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Sendfile' do |response|
-      response.body.should.equal 'Not a file...'
-      response.headers.should.not.include 'X-Sendfile'
+      response.body.should eq('Not a file...')
+      response.headers.should_not include 'X-Sendfile'
     end
   end
 end

--- a/test/spec_rack_simple_endpoint.rb
+++ b/test/spec_rack_simple_endpoint.rb
@@ -1,9 +1,8 @@
-require 'test/spec'
 require 'rack'
 require 'rack/contrib/simple_endpoint'
 
-context "Rack::SimpleEndpoint" do
-  setup do
+describe "Rack::SimpleEndpoint" do
+  before do
     @app = Proc.new { Rack::Response.new {|r| r.write "Downstream app"}.finish }
   end
 
@@ -58,23 +57,23 @@ context "Rack::SimpleEndpoint" do
 
   specify "block yields Rack::Request and Rack::Response objects" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') do |req, res|
-      assert_instance_of ::Rack::Request, req
-      assert_instance_of ::Rack::Response, res
+      req.should be_instance_of ::Rack::Request
+      res.should be_instance_of ::Rack::Response
     end
     endpoint.call(Rack::MockRequest.env_for('/foo'))
   end
 
   specify "block yields MatchData object when Regex path matcher specified" do
     endpoint = Rack::SimpleEndpoint.new(@app, /foo(.+)/) do |req, res, match|
-      assert_instance_of MatchData, match
-      assert_equal 'bar', match[1]
+      match.should be_instance_of MatchData
+      match[1].should == 'bar'
     end
     endpoint.call(Rack::MockRequest.env_for('/foobar'))
   end
 
   specify "block does NOT yield MatchData object when String path matcher specified" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') do |req, res, match|
-      assert_nil match
+      match.should be_nil
     end
     endpoint.call(Rack::MockRequest.env_for('/foo'))
   end

--- a/test/spec_rack_static_cache.rb
+++ b/test/spec_rack_static_cache.rb
@@ -1,4 +1,3 @@
-require 'test/spec'
 
 require 'rack'
 require 'rack/contrib/static_cache'
@@ -12,14 +11,14 @@ end
 
 describe "Rack::StaticCache" do
 
-  setup do
+  before do
     @root = ::File.expand_path(::File.dirname(__FILE__))
   end
 
   it "should serve files with required headers" do
     default_app_request
     res = @request.get("/statics/test")
-    res.should.be.ok
+    res.should be_ok
     res.body.should =~ /rubyrack/
     res.headers['Cache-Control'].should == 'max-age=31536000, public'
      next_year = Time.now().year + 1
@@ -34,26 +33,26 @@ describe "Rack::StaticCache" do
   it "should return 404s if url root is known but it can't find the file" do
     default_app_request
     res = @request.get("/statics/foo")
-    res.should.be.not_found
+    res.should be_not_found
   end
 
   it "should call down the chain if url root is not known" do
     default_app_request
     res = @request.get("/something/else")
-    res.should.be.ok
+    res.should be_ok
     res.body.should == "Hello World"
   end
 
   it "should serve files if requested with version number and versioning is enabled" do
     default_app_request
     res = @request.get("/statics/test-0.0.1")
-    res.should.be.ok
+    res.should be_ok
   end
 
   it "should change cache duration if specified thorugh option" do
     configured_app_request
     res = @request.get("/statics/test")
-    res.should.be.ok
+    res.should be_ok
     res.body.should =~ /rubyrack/
     next_next_year = Time.now().year + 2
     res.headers['Expires'].should =~ Regexp.new("#{next_next_year}")
@@ -62,16 +61,16 @@ describe "Rack::StaticCache" do
   it "should return 404s if requested with version number but versioning is disabled" do
     configured_app_request
     res = @request.get("/statics/test-0.0.1")
-    res.should.be.not_found
+    res.should be_not_found
   end
 
   it "should serve files with plain headers when * is added to the directory name" do
     configured_app_request
     res = @request.get("/documents/test")
-    res.should.be.ok
+    res.should be_ok
     res.body.should =~ /nocache/
     next_next_year = Time.now().year + 2
-    res.headers['Expires'].should.not =~ Regexp.new("#{next_next_year}")
+    res.headers['Expires'].should_not =~ Regexp.new("#{next_next_year}")
   end
 
   def default_app_request

--- a/test/spec_rack_try_static.rb
+++ b/test/spec_rack_try_static.rb
@@ -1,4 +1,3 @@
-require 'test/spec'
 
 require 'rack'
 require 'rack/contrib/try_static'
@@ -23,7 +22,7 @@ describe "Rack::TryStatic" do
   context 'when file cannot be found' do
     it 'should call call app' do
       res = request(build_options(:try => ['html'])).get('/documents')
-      res.should.be.ok
+      res.should be_ok
       res.body.should == "Hello World"
     end
   end
@@ -31,7 +30,7 @@ describe "Rack::TryStatic" do
   context 'when file can be found' do
     it 'should serve first found' do
       res = request(build_options(:try => ['.html', '/index.html', '/index.htm'])).get('/documents')
-      res.should.be.ok
+      res.should be_ok
       res.body.strip.should == "index.html"
     end
   end
@@ -39,7 +38,7 @@ describe "Rack::TryStatic" do
   context 'when path_info maps directly to file' do
     it 'should serve existing' do
       res = request(build_options(:try => ['/index.html'])).get('/documents/existing.html')
-      res.should.be.ok
+      res.should be_ok
       res.body.strip.should == "existing.html"
     end
   end
@@ -48,8 +47,8 @@ describe "Rack::TryStatic" do
     it 'should not mutate given options' do
       org_options = build_options  :try => ['/index.html']
       given_options = org_options.dup
-      request(given_options).get('/documents').should.be.ok
-      request(given_options).get('/documents').should.be.ok
+      request(given_options).get('/documents').should be_ok
+      request(given_options).get('/documents').should be_ok
       given_options.should == org_options
     end
   end


### PR DESCRIPTION
Getting Test::Spec & Test::Unit working under Ruby 1.9 was a dead end. It was much easier for me to bring in rspec.

MiniTest was considered but the matcher syntax already present is much closer to what RSpec uses.

Five tests fail for me in this PR, but they're the same five tests that fail in the origin/master, so I'm guessing that's not my fault :)