### PR TITLE
EnforceValidEncoding middleware.

### DIFF
--- a/lib/rack/contrib/enforce_valid_encoding.rb
+++ b/lib/rack/contrib/enforce_valid_encoding.rb
@@ -1,0 +1,17 @@
+module Rack
+  class EnforceValidEncoding
+
+    def initialize app
+      @app = app
+    end
+
+    def call env
+      full_path = (env.fetch('PATH_INFO', '') + env.fetch('QUERY_STRING', ''))
+      if full_path.valid_encoding? && Rack::Utils.unescape(full_path).valid_encoding?
+        @app.call env
+      else
+        [400, {'Content-Type'=>'text/plain'}, ['Bad Request']]
+      end
+    end
+  end
+end

--- a/test/spec_rack_enforce_valid_encoding.rb
+++ b/test/spec_rack_enforce_valid_encoding.rb
@@ -1,0 +1,53 @@
+# -*- encoding : us-ascii -*-
+if "a string".respond_to?(:valid_encoding?)
+  require 'rack/mock'
+  require 'rack/contrib/enforce_valid_encoding'
+
+  VALID_PATH = "h%C3%A4ll%C3%B2"
+  INVALID_PATH = "/%D1%A1%D4%F1%D7%A2%B2%E1%D3%C3%BB%A7%C3%FB"
+
+  describe "Rack::EnforceValidEncoding" do
+    before do
+      @app = Rack::EnforceValidEncoding.new(lambda { |env|
+        [200, {'Content-Type'=>'text/plain'}, ['Hello World']]
+      })
+    end
+
+    describe "contstant assertions" do
+      it "INVALID_PATH should not be a valid UTF-8 string when decoded" do
+        Rack::Utils.unescape(INVALID_PATH).valid_encoding?.should.equal false
+      end
+
+      it "VALID_PATH should be valid when decoded" do
+        Rack::Utils.unescape(VALID_PATH).valid_encoding?.should.equal true
+      end
+    end
+
+    it "should accept a request with a correctly encoded path" do
+      response = Rack::MockRequest.new(@app).get(VALID_PATH)
+      response.body.should.equal("Hello World")
+      response.status.should.equal(200)
+    end
+
+    it "should reject a request with a poorly encoded path" do
+      response = Rack::MockRequest.new(@app).get(INVALID_PATH)
+      response.status.should.equal(400)
+    end
+
+    it "should accept a request with a correctly encoded query string" do
+      response = Rack::MockRequest.new(@app).get('/', 'QUERY_STRING' => VALID_PATH)
+      response.body.should.equal("Hello World")
+      response.status.should.equal(200)
+    end
+
+    it "should reject a request with a poorly encoded query string" do
+      response = Rack::MockRequest.new(@app).get('/', 'QUERY_STRING' => INVALID_PATH)
+      response.status.should.equal(400)
+    end
+
+    it "should reject a request containing malformed multibyte characters" do
+      response = Rack::MockRequest.new(@app).get('/', 'QUERY_STRING' => Rack::Utils.unescape(INVALID_PATH, Encoding::ASCII_8BIT))
+      response.status.should.equal(400)
+    end
+  end
+end


### PR DESCRIPTION
Since migrating our application to Ruby 1.9 from Ruby 1.8 most of our logged exceptions have been due to spam bots sending bad UTF8 in query strings and paths.

This middleware rejects any path or query string that does not decode correctly.

The test in this PR depends on my other pull request that converts rack-contrib's specs to use bacon instead of specrb.