### PR TITLE
Allow PostBodyContentTypeParser Middleware to use a custom json parser

### DIFF
--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -24,14 +24,15 @@ module Rack
     #
     APPLICATION_JSON = 'application/json'.freeze
 
-    def initialize(app)
+    def initialize(app, &block)
       @app = app
+      @block = block_given? ? block : Proc.new {|body| JSON.parse(body)}
     end
 
     def call(env)
       if Rack::Request.new(env).media_type == APPLICATION_JSON && (body = env[POST_BODY].read).length != 0
         env[POST_BODY].rewind # somebody might try to read this stream
-        env.update(FORM_HASH => JSON.parse(body), FORM_INPUT => env[POST_BODY])
+        env.update(FORM_HASH => @block.call(body), FORM_INPUT => env[POST_BODY])
       end
       @app.call(env)
     end

--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -101,6 +101,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'test-spec', '>= 0.9.0'
   s.add_development_dependency 'tmail', '>= 1.2'
   s.add_development_dependency 'json', '>= 1.1'
+  s.add_development_dependency 'oj', '>= 2.0.3'
 
   s.has_rdoc = true
   s.homepage = "http://github.com/rack/rack-contrib/"

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -1,5 +1,6 @@
 require 'test/spec'
 require 'rack/mock'
+require 'oj'
 
 begin
   require 'rack/contrib/post_body_content_type_parser'
@@ -15,7 +16,7 @@ begin
       params = params_for_request '{"key":"value"}', "application/json; charset=utf-8"
       params['key'].should.equal "value"
     end
-    
+
     specify "should parse 'application/json' requests with empty body" do
       params = params_for_request "", "application/json"
       params.should.equal({})
@@ -26,6 +27,14 @@ begin
       params['key'].should.equal "value"
     end
 
+    specify "should parse 'application/json' requests with a custom json parser" do
+      env = Rack::MockRequest.env_for "/", {:method => "POST", :input => body, "CONTENT_TYPE" => content_type}
+      app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST] }
+      params = Rack::PostBodyContentTypeParser.new(app) do |body|
+        Oj.load(body)
+      end.call(env).last
+      params['key'].should.equal "value"
+    end
   end
 
   def params_for_request(body, content_type)
@@ -33,7 +42,7 @@ begin
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST] }
     Rack::PostBodyContentTypeParser.new(app).call(env).last
   end
-  
+
 rescue LoadError => e
   # Missing dependency JSON, skipping tests.
   STDERR.puts "WARN: Skipping Rack::PostBodyContentTypeParser tests (json not installed)"


### PR DESCRIPTION
I added the ability to add a custom json parser to the PostBodyContentTypeParser middleware. It now takes a block that passes in the request body, there you can call `Oj.load(body)` or `Yajl::Parser.parse(body)` depending on the parser you want to use. Here's an example:

```ruby
use Rack::PostBodyContentTypeParser do |body|
  Oj.load(body)
end
```

I couldn't get the test suite to run at all locally, so I hope the tests pass.