### PR TITLE
Set :create_additions to false when parsing json

### DIFF
--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -30,7 +30,7 @@ module Rack
 
     def call(env)
       if Rack::Request.new(env).media_type == APPLICATION_JSON && (body = env[POST_BODY].read).length != 0
-        env.update(FORM_HASH => JSON.parse(body), FORM_INPUT => env[POST_BODY])
+        env.update(FORM_HASH => JSON.parse(body, :create_additions => false), FORM_INPUT => env[POST_BODY])
       end
       @app.call(env)
     end

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -26,6 +26,13 @@ begin
       params['key'].should.equal "value"
     end
 
+    specify "should not create additions" do
+      before = Symbol.all_symbols
+      params_for_request %{{"json_class":"this_should_not_be_added"}}, "application/json" rescue nil
+      result = Symbol.all_symbols - before
+      result.should.be.empty
+    end
+
   end
 
   def params_for_request(body, content_type)


### PR DESCRIPTION
This is in response to CVE-2013-0269. See
https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/4_YvCpLzL58
for details.

Another option is using `multi_json` which takes care of the problem (and allows for usage of any json gem).