### PR TITLE
TryStatic should treat HTTP 405 as an error

### DIFF
--- a/lib/rack/contrib/try_static.rb
+++ b/lib/rack/contrib/try_static.rb
@@ -28,7 +28,7 @@ module Rack
       found = nil
       @try.each do |path|
         resp = @static.call(env.merge!({'PATH_INFO' => orig_path + path}))
-        break if 404 != resp[0] && found = resp
+        break if ![404, 405].include?(resp[0]) && found = resp
       end
       found or @app.call(env.merge!('PATH_INFO' => orig_path))
     end


### PR DESCRIPTION
Rack::TryStatic calls Rack::Static, which calls Rack::File.  Rack::File returns an HTTP 405 if the HTTP method is something other than GET or HEAD (https://github.com/rack/rack/blob/master/lib/rack/file.rb#L38). The 405 gets returned up the stack to TryStatic.

However, TryStatic only looks for 404 as an error, not 405. So it thinks the static request has succeeded and does not proceed to call the app.

So, if you attempt to POST, PUT, DELETE, etc. with TryStatic in your middleware stack, it will always fail with HTTP 405.

This PR changes TryStatic to look for HTTP 405 as well, and treat it the same way as HTTP 404 (i.e. pass the request to the app).

I can't get the tests for this gem to run, so I have not run them or added a test for this case.  I would like to have test coverage, but digging into the testing is not the best use of my time right now.  The modified gem works as expected in my app.