### PR TITLE
Only looks for static files if it's a GET request

### DIFF
--- a/lib/rack/contrib/try_static.rb
+++ b/lib/rack/contrib/try_static.rb
@@ -26,7 +26,7 @@ module Rack
     def call(env)
       orig_path = env['PATH_INFO']
       found = nil
-      if env['REQUEST_METHOD'] == 'GET'
+      if %w(GET HEAD).include? env['REQUEST_METHOD']
         @try.each do |path|
           resp = @static.call(env.merge!({'PATH_INFO' => orig_path + path}))
           break if 404 != resp[0] && found = resp


### PR DESCRIPTION
Rack Try Static currently looks for static assets no matter what the request method.

This causes errors when a POST or PUT method comes through. It returns a 405 and does not continue trying to fulfil that request in the rest of the app.

GET is the only request type it can actually get a static asset for so why not just check for static assets for this request method only?

BTW there are not tests with this pull request. I read the readme on testing and without bundler it just took way too long and I didn't get anywhere.
