### PR TITLE
Check HTTP_X_FORWARDED_FOR when deflecting

### DIFF
--- a/lib/rack/contrib/deflect.rb
+++ b/lib/rack/contrib/deflect.rb
@@ -67,7 +67,7 @@ module Rack
     end
 
     def deflect? env
-      @remote_addr = env['REMOTE_ADDR']
+      @remote_addr = env['HTTP_X_FORWARDED_FOR']
       return false if options[:whitelist].include? @remote_addr
       return true  if options[:blacklist].include? @remote_addr
       sync { watch }

--- a/lib/rack/contrib/deflect.rb
+++ b/lib/rack/contrib/deflect.rb
@@ -68,6 +68,7 @@ module Rack
 
     def deflect? env
       @remote_addr = env['HTTP_X_FORWARDED_FOR']
+      @remote_addr = env['REMOTE_ADDR'] unless @remote_addr && @remote_addr != ''
       return false if options[:whitelist].include? @remote_addr
       return true  if options[:blacklist].include? @remote_addr
       sync { watch }

--- a/test/spec_rack_deflect.rb
+++ b/test/spec_rack_deflect.rb
@@ -15,6 +15,10 @@ context "Rack::Deflect" do
     Rack::MockRequest.env_for path, { 'REMOTE_ADDR' => remote_addr }
   end
 
+  def mock_proxied_env remote_addr, path = '/'
+    Rack::MockRequest.env_for path, { 'REMOTE_ADDR' => '10.10.10.10', 'HTTP_X_FORWARDED_FOR' => remote_addr }
+  end
+
   def mock_deflect options = {}
     Rack::Deflect.new @app, options
   end
@@ -100,6 +104,10 @@ context "Rack::Deflect" do
     body.should.equal ['cookies']
 
     status, headers, body = app.call mock_env(@mock_addr_2)
+    status.should.equal 403
+    body.should.equal []
+
+    status, headers, body = app.call mock_proxied_env(@mock_addr_2)
     status.should.equal 403
     body.should.equal []
   end


### PR DESCRIPTION

add ability to deflect requests from original client IP
…even when it's been forwarded through a proxy.

Use Case:  On Heroku, rack::deflect didn't block
what we wanted because the proxy IP in REMOTE_ADDR
was different for each request during a DOS
we experienced (but the original client IP in
HTTP_X_FORWARDED_FOR was the same).  By patching 
rack-deflect to check the forwarded header first
(and fall back to REMOTE_ADDR if it's not there) 
we were able to deflect it successfully.