### PR TITLE
Ensure duration_in_seconds - and hence max-age - has an integer value

### DIFF
--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -87,7 +87,7 @@ module Rack
     end
 
     def duration_in_seconds
-      60 * 60 * 24 * 365 * @cache_duration
+      (60 * 60 * 24 * 365 * @cache_duration).to_i
     end
   end
 end

--- a/test/spec_rack_static_cache.rb
+++ b/test/spec_rack_static_cache.rb
@@ -59,6 +59,14 @@ describe "Rack::StaticCache" do
     res.headers['Expires'].should =~ Regexp.new("#{next_next_year}")
   end
 
+  it "should round max-age if duration is part of a year" do
+    one_week_duration_app_request
+    res = @request.get("/statics/test")
+    res.should.be.ok
+    res.body.should =~ /rubyrack/
+    res.headers['Cache-Control'].should == "max-age=606461, public"
+  end
+
   it "should return 404s if requested with version number but versioning is disabled" do
     configured_app_request
     res = @request.get("/statics/test-0.0.1")
@@ -76,6 +84,11 @@ describe "Rack::StaticCache" do
 
   def default_app_request
     @options = {:urls => ["/statics"], :root => @root}
+    request
+  end
+
+  def one_week_duration_app_request
+    @options = {:urls => ["/statics"], :root => @root, :duration => 1.fdiv(52)}
     request
   end
 


### PR DESCRIPTION
This is a small change to ensure that the `max-age` value in the `Cache-Control` header is an **integer**, not a **float**;  this is especially relevant when setting the `duration` option for `Rack::StaticCache` to part of a year _(instead of multiples of a year)_

This requirement is covered by RFC 2616; from http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6

> Age values are non-negative decimal integers, representing time in seconds.

**example** - set duration to 1 week

``` ruby
use Rack::StaticCache,
  ...
  :duration => 1.fdiv(52)
```

**before** - `max-age=606461.5384615385`

```
$ curl -I http://localhost:5000/images/logo.png
HTTP/1.1 200 OK
Content-Type: image/png
Cache-Control: max-age=606461.5384615385, public
Expires: Sat, 09 Nov 2013 12:03:38 GMT
Content-Length: 18025
```

**after** - `max-age=606461`

```
curl -I http://localhost:5000/images/logo.png
HTTP/1.1 200 OK
Content-Type: image/png
Cache-Control: max-age=606461, public
Expires: Sat, 09 Nov 2013 12:27:33 GMT
Content-Length: 18025
```
