### PR TITLE
Prevent malformed class names for Rack::Profiler

### DIFF
--- a/lib/rack/contrib/profiler.rb
+++ b/lib/rack/contrib/profiler.rb
@@ -82,7 +82,7 @@ module Rack
         if printer.is_a?(Class)
           printer
         else
-          name = "#{camel_case(printer)}Printer" unless name.match /Printer$/
+          name = "#{camel_case(printer)}Printer" unless printer.match /Printer$/
           if ::RubyProf.const_defined?(name)
             ::RubyProf.const_get(name)
           else


### PR DESCRIPTION
In the event that the provided printer's class name has "Provider"; don't try forcing "Printer" on to it; or you'd get RubyProf::GraphPrinterPrinter. This is a light fix for the attached:
![snapshot63](https://f.cloud.github.com/assets/452100/1598358/55a958b6-532d-11e3-8482-44b5e644899f.png)
