### PR TITLE
Rack::StaticCache: use semver for asset versioning

### DIFF
--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -67,7 +67,14 @@ module Rack
       path = env["PATH_INFO"]
       url = @urls.detect{ |u| path.index(u) == 0 }
       unless url.nil?
-        path.sub!(/-[\d.]+([.][a-zA-Z][\w]+)?$/, '\1') if @versioning_enabled
+        if @versioning_enabled
+          path.sub!(/
+            -               # a literal dash
+            (\d+\.\d+\.\d+) # basic MAJOR.MINOR.PATCH semver
+            (\.[0-9a-z]+)?  # an optional file extension containing numbers or letters
+            \z              # end of string
+          /x, '\1')         # /x allows spaces in regex for comments; \1 tells sub! to delete the match
+        end
         status, headers, body = @file_server.call(env)
         if @no_cache[url].nil?
           headers['Cache-Control'] ="max-age=#{@duration_in_seconds}, public"


### PR DESCRIPTION
Unfortunately the previous regex matched files ending with - followed by any number. This comes up a lot and I'm getting 404s for dozens of our files.

I suggest using a simplified semvar of `x.x.x` (x being 0-9) (unless we want to use the [full semver spec regex](https://github.com/mojombo/semver/issues/32#issuecomment-7663411)).

This passes the current versioning tests for a `-1.0.0` ending. Feel free to try the regex out at [this rubular test](http://rubular.com/r/sZ2raKn98v) (using $ in rubular example to allow for multiple matches).