### PR TITLE
Allow Etag/Last-Modified headers in Rack::StaticCache

### DIFF
--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -72,9 +72,6 @@ module Rack
         if @no_cache[url].nil?
           headers['Cache-Control'] ="max-age=#{@duration_in_seconds}, public"
           headers['Expires'] = @duration_in_words
-          headers.delete 'Etag'
-          headers.delete 'Pragma'
-          headers.delete 'Last-Modified'
         end
         [status, headers, body]
       else

--- a/test/spec_rack_static_cache.rb
+++ b/test/spec_rack_static_cache.rb
@@ -26,9 +26,6 @@ describe "Rack::StaticCache" do
     res.headers['Expires'].must_match(Regexp.new(
         "[A-Z][a-z]{2}[,][\s][0-9]{2}[\s][A-Z][a-z]{2}[\s]" << "#{next_year}" <<
         "[\s][0-9]{2}[:][0-9]{2}[:][0-9]{2} GMT$"))
-    res.headers.has_key?('Etag').must_equal false
-    res.headers.has_key?('Pragma').must_equal false
-    res.headers.has_key?('Last-Modified').must_equal false
   end
 
   it "should return 404s if url root is known but it can't find the file" do


### PR DESCRIPTION
Server side caching techniques shouldn't be disallowed.

See: https://github.com/rack/rack-contrib/commit/3f42d3afe7323d322567d77cd404fb5bd8d9f1eb#commitcomment-5084830