### PR TITLE
Preventing unintended overwrite of Content-Language header

### DIFF
--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -13,7 +13,7 @@ module Rack
         locale = accept_locale(env) || I18n.default_locale
         locale = env['rack.locale'] = I18n.locale = locale.to_s
         status, headers, body = @app.call(env)
-        headers['Content-Language'] = locale
+        headers['Content-Language'] = locale unless headers['Content-Language']
         [status, headers, body]
       ensure
         I18n.locale = old_locale


### PR DESCRIPTION
This will prevent us to overwrite the Content-Language header if
the application sets it properly.

Fixes #88 