### PR TITLE
Make JSONP a noop when the status is 1xx, 204 or 304.

### DIFF
--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -37,6 +37,10 @@ module Rack
 
       status, headers, response = @app.call(env)
 
+      if STATUS_WITH_NO_ENTITY_BODY.include?(status)
+        return status, headers, response
+      end
+
       headers = HeaderHash.new(headers)
       
       if is_json?(headers) && has_callback?(request)

--- a/test/spec_rack_jsonp.rb
+++ b/test/spec_rack_jsonp.rb
@@ -185,4 +185,13 @@ describe "Rack::JSONP" do
     body.must_equal [test_body]
   end  
 
+  specify "should not change anything if the request doesn't have a body" do
+    app1 = lambda { |env| [100, {}, []] }
+    app2 = lambda { |env| [204, {}, []] }
+    app3 = lambda { |env| [304, {}, []] }
+    request = Rack::MockRequest.env_for("/", :params => "callback=foo", 'HTTP_ACCEPT' => 'application/json')
+    Rack::JSONP.new(app1).call(request).must_equal app1.call({})
+    Rack::JSONP.new(app2).call(request).must_equal app2.call({})
+    Rack::JSONP.new(app3).call(request).must_equal app3.call({})
+  end
 end


### PR DESCRIPTION
This fixes #8, and is simply an update of the patch referenced in that issue.