### PR TITLE
Filter out HTTP_AUTHORIZATION header contents

### DIFF
--- a/lib/rack/contrib/mailexceptions.rb
+++ b/lib/rack/contrib/mailexceptions.rb
@@ -76,7 +76,7 @@ module Rack
   private
     def generate_mail(exception, env)
       Mail.new({
-        :from => config[:from], 
+        :from => config[:from],
         :to => config[:to],
         :subject => config[:subject] % [exception.to_s],
         :body => @template.result(binding),
@@ -129,7 +129,12 @@ module Rack
 
       <%= env.to_a.
         sort{|a,b| a.first <=> b.first}.
-        map{ |k,v| "%-25s%p" % [k+':', v] }.
+        map do |k,v|
+          if k == 'HTTP_AUTHORIZATION' and v =~ /^Basic /
+            v = 'Basic *filtered*'
+         end
+          "%-25s%p" % [k+':', v]
+        end.
         join("\n  ") %>
 
     <% if exception.respond_to?(:backtrace) %>

--- a/test/spec_rack_mailexceptions.rb
+++ b/test/spec_rack_mailexceptions.rb
@@ -64,6 +64,22 @@ begin
       mail.body.to_s.must_match(/^\s*THE BODY\s*$/)
     end
 
+    specify 'filters HTTP_EXCEPTION body' do
+      mailer =
+        Rack::MailExceptions.new(@app) do |mail|
+          mail.to 'foo@example.org'
+          mail.from 'bar@example.org'
+          mail.subject '[ERROR] %s'
+          mail.smtp @smtp_settings
+        end
+
+      env = @env.dup
+      env['HTTP_AUTHORIZATION'] = 'Basic xyzzy12345'
+
+      mail = mailer.send(:generate_mail, test_exception, env)
+      mail.body.to_s.must_match /HTTP_AUTHORIZATION:\s+"Basic \*filtered\*"/
+    end
+
     specify 'catches exceptions raised from app, sends mail, and re-raises' do
       mailer =
         Rack::MailExceptions.new(@app) do |mail|


### PR DESCRIPTION
Yeah, e-mailing everyone the base64-encoded credentials for every HTTP basic
auth'd request that generates an error... not cool.  Not cool at *all*.