### PR TITLE
Rack::Profiler: run a single request multiple times with a query parameter

### DIFF
--- a/lib/rack/contrib/profiler.rb
+++ b/lib/rack/contrib/profiler.rb
@@ -27,6 +27,7 @@ module Rack
 
     def call(env)
       if mode = profiling?(env)
+        @times = @request.params['times'].to_i if @request.params['times']
         profile(env, mode)
       else
         @app.call(env)
@@ -36,8 +37,8 @@ module Rack
     private
       def profiling?(env)
         unless ::RubyProf.running?
-          request = Rack::Request.new(env.clone)
-          if mode = request.params.delete('profile')
+          @request = Rack::Request.new(env.clone)
+          if mode = @request.params.delete('profile')
             if ::RubyProf.const_defined?(mode.upcase)
               mode
             else

--- a/lib/rack/contrib/profiler.rb
+++ b/lib/rack/contrib/profiler.rb
@@ -5,6 +5,12 @@ module Rack
   # calltree profile of the request.
   #
   # Pass the :printer option to pick a different result format.
+  #
+  # You can cause every request to be run multiple times by passing the
+  # `:times` option to the `use Rack::Profiler` call.  You can also run a
+  # given request multiple times, by setting the `profiler_runs` query
+  # parameter in the request URL.
+  #
   class Profiler
     MODES = %w(process_time wall_time cpu_time
                allocations memory gc_runs gc_time)
@@ -27,7 +33,6 @@ module Rack
 
     def call(env)
       if mode = profiling?(env)
-        @times = @request.params['times'].to_i if @request.params['times']
         profile(env, mode)
       else
         @app.call(env)
@@ -37,8 +42,8 @@ module Rack
     private
       def profiling?(env)
         unless ::RubyProf.running?
-          @request = Rack::Request.new(env.clone)
-          if mode = @request.params.delete('profile')
+          request = Rack::Request.new(env.clone)
+          if mode = request.params.delete('profile')
             if ::RubyProf.const_defined?(mode.upcase)
               mode
             else
@@ -54,8 +59,10 @@ module Rack
         ::RubyProf.measure_mode = ::RubyProf.const_get(mode.upcase)
 
         GC.enable_stats if GC.respond_to?(:enable_stats)
+        request = Rack::Request.new(env.clone)
+        runs = (request.params['profiler_runs'] || @times).to_i
         result = ::RubyProf.profile do
-          @times.times { @app.call(env) }
+          runs.times { @app.call(env) }
         end
         GC.disable_stats if GC.respond_to?(:disable_stats)
 

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -15,7 +15,7 @@ begin
     end
 
     specify 'called multiple times via query params' do
-      req = Rack::MockRequest.env_for("/", :params => "profile=process_time&times=4")
+      req = Rack::MockRequest.env_for("/", :params => "profile=process_time&profiler_runs=4")
       body = Rack::Profiler.new(app).call(req)[2].string
       body.must_match(/Proc#call \[4 calls, 4 total\]/)
     end

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -17,7 +17,7 @@ begin
     specify 'called multiple times via query params' do
       req = Rack::MockRequest.env_for("/", :params => "profile=process_time&times=4")
       body = Rack::Profiler.new(app).call(req)[2].string
-      body.must_match(/Fixnum#to_s \[4 calls, 4 total\]/)
+      body.must_match(/Proc#call \[4 calls, 4 total\]/)
     end
 
     specify 'CallStackPrinter has Content-Type test/html' do

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -14,6 +14,11 @@ begin
       profiler.instance_variable_get('@times').must_equal 1
     end
 
+    specify 'call @times globally and times is set' do
+        profiler = Rack::Profiler.new(app, :times => 4) 
+        profiler.instance_variable_get('@times').should.equal 4
+    end
+
     specify 'CallStackPrinter has Content-Type test/html' do
       headers = Rack::Profiler.new(app, :printer => :call_stack).call(request)[1]
       headers.must_equal "Content-Type"=>"text/html"

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -14,9 +14,10 @@ begin
       profiler.instance_variable_get('@times').must_equal 1
     end
 
-    specify 'call @times globally and times is set' do
-        profiler = Rack::Profiler.new(app, :times => 4) 
-        profiler.instance_variable_get('@times').should.equal 4
+    specify 'called multiple times via query params' do
+      req = Rack::MockRequest.env_for("/", :params => "profile=process_time&times=4")
+      body = Rack::Profiler.new(app).call(req)[2].string
+      body.must_match(/Fixnum#to_s \[4 calls, 4 total\]/)
     end
 
     specify 'CallStackPrinter has Content-Type test/html' do


### PR DESCRIPTION
This is a cleaned-up version of #52, which (IMO) meets the requirements for merge.