### PR TITLE
Released version should not depend on git-version-bump

### DIFF
--- a/lib/rack/contrib.rb
+++ b/lib/rack/contrib.rb
@@ -1,10 +1,9 @@
 require 'rack'
-require 'git-version-bump'
 
 module Rack
   module Contrib
     def self.release
-      GVB.version
+      Gem::Specification.find_by_name("rack-contrib").version.to_s
     end
   end
 

--- a/lib/rack/contrib.rb
+++ b/lib/rack/contrib.rb
@@ -3,7 +3,14 @@ require 'rack'
 module Rack
   module Contrib
     def self.release
-      Gem::Specification.find_by_name("rack-contrib").version.to_s
+      require "git-version-bump"
+      GVB.version
+    rescue LoadError
+      begin
+        Gem::Specification.find_by_name("rack-contrib").version.to_s
+      rescue Gem::LoadError
+        "0.0.0.1.ENOTAG"
+      end
     end
   end
 

--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |s|
   # update `test/gemfiles/minimum_versions`!
   #
   s.add_runtime_dependency 'rack', '~> 1.4'
-  s.add_runtime_dependency 'git-version-bump', '~> 0.15'
 
   s.add_development_dependency 'bundler', '~> 1.0'
+  s.add_development_dependency 'git-version-bump', '~> 0.15'
   s.add_development_dependency 'github-release', '~> 0.1'
   s.add_development_dependency 'i18n', '~> 0.4'
   s.add_development_dependency 'json', '~> 1.8'


### PR DESCRIPTION
It's used for managing the release versions, but should not be included in the dependencies for others that depend on rack-contrib.

Lookup version number from our own gem spec instead.
