### PR TITLE
When enforce_available_locales is enabled only set available locales

### DIFF
--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -34,7 +34,13 @@ module Rack
 
       lang = languages_and_qvalues.sort_by { |(locale, qvalue)|
         qvalue.to_f
-      }.last.first
+      }.reverse.detect { |(locale, qvalue)|
+        if I18n.enforce_available_locales
+          locale == '*' || I18n.available_locales.include?(locale.to_sym)
+        else
+          true
+        end
+      }.first
 
       lang == '*' ? nil : lang
     end

--- a/test/gemfiles/minimum_versions
+++ b/test/gemfiles/minimum_versions
@@ -7,7 +7,7 @@ source 'https://rubygems.org'
 #
 gem 'rack',                '= 1.4.0'
 gem 'git-version-bump',    '= 0.15.0'
-gem 'i18n',                '= 0.4.0'
+gem 'i18n',                '= 0.5.2'
 gem 'json',                '= 1.8.1'
 gem 'minitest',            '= 5.6.0'
 gem 'minitest-hooks',      '= 1.0.0'


### PR DESCRIPTION
This PR implements https://github.com/rack/rack-contrib/issues/14

When the enforce_available_locales flag is enabled, which is the default setting a locale that is not in the list of available locales an InvalidLocale exception is raised. With this changes we're going to set only available locales when is enabled, and any locale when it's not.

A slightly difference with the proposal code from the issue is that we're comparing the full language codes without fallback. So I'm not sure if this PR is too restricted in this way
