### PR TITLE
Add a default response to Rack::NotFound if no 404 page specified

### DIFF
--- a/lib/rack/contrib/not_found.rb
+++ b/lib/rack/contrib/not_found.rb
@@ -1,13 +1,25 @@
 module Rack
-  # Rack::NotFound is a default endpoint. Initialize with the path to
-  # your 404 page.
+  # Rack::NotFound is a default endpoint. Optionally initialize with the
+  # path to a custom 404 page, to override the standard response body.
+  #
+  # Examples:
+  #
+  # Serve default 404 response:
+  #   run Rack::NotFound.new
+  #
+  # Serve a custom 404 page:
+  #   run Rack::NotFound.new('path/to/your/404.html')
 
   class NotFound
     F = ::File
 
-    def initialize(path)
-      file = F.expand_path(path)
-      @content = F.read(file)
+    def initialize(path = '')
+      if path.empty?
+        @content = "Not found\n"
+      else
+        file = F.expand_path(path)
+        @content = F.read(file)
+      end
       @length = @content.size.to_s
     end
 

--- a/test/404.html
+++ b/test/404.html
@@ -1,1 +1,1 @@
-Not Found
+Custom 404 page content

--- a/test/spec_rack_not_found.rb
+++ b/test/spec_rack_not_found.rb
@@ -10,7 +10,19 @@ describe "Rack::NotFound" do
       run Rack::NotFound.new('test/404.html')
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal('Not Found')
+    response.body.must_equal('Custom 404 page content')
+    response.headers['Content-Length'].must_equal('23')
+    response.status.must_equal(404)
+  end
+
+  specify "should render the default response body if no path specified" do
+    app = Rack::Builder.new do
+      use Rack::Lint
+      run Rack::NotFound.new
+    end
+    response = Rack::MockRequest.new(app).get('/')
+    response.body.must_equal("Not found\n")
+    response.headers['Content-Length'].must_equal('10')
     response.status.must_equal(404)
   end
 


### PR DESCRIPTION
The `path` argument to `NotFound` is now optional, and if not provided a default response is returned instead of the file contents.

The tests have also been updated to check Content-Length is correct.

Fixes #117.
