### PR TITLE
Do not use removed Rack 2.0 `bytesize` method

### DIFF
--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -54,7 +54,7 @@ module Rack
         
         # Set new Content-Length, if it was set before we mutated the response body
         if headers['Content-Length']
-          length = response.to_ary.inject(0) { |len, part| len + bytesize(part) }
+          length = response.to_ary.inject(0) { |len, part| len + part.bytesize }
           headers['Content-Length'] = length.to_s
         end
       end


### PR DESCRIPTION
cc @mpalmer @tenderlove 

`Rack::Utils#bytesize` was removed in https://github.com/rack/rack/commit/7b5820f8de7f9dffeb03d86588bba13fb0e91df1.
