### PR TITLE
Fix license violation of git-version-bump gem

### DIFF
--- a/lib/rack/contrib.rb
+++ b/lib/rack/contrib.rb
@@ -3,9 +3,6 @@ require 'git-version-bump'
 
 module Rack
   module Contrib
-    def self.release
-      GVB.version
-    end
   end
 
   autoload :AcceptFormat,               "rack/contrib/accept_format"

--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |s|
   # update `test/gemfiles/minimum_versions`!
   #
   s.add_runtime_dependency 'rack', '~> 1.4'
-  s.add_runtime_dependency 'git-version-bump', '~> 0.15'
 
+  s.add_development_dependency 'git-version-bump', '~> 0.15'
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'github-release', '~> 0.1'
   s.add_development_dependency 'i18n', '~> 0.4'

--- a/test/spec_rack_contrib.rb
+++ b/test/spec_rack_contrib.rb
@@ -1,8 +1,0 @@
-require 'minitest/autorun'
-require 'rack/contrib'
-
-describe "Rack::Contrib" do
-  specify "should expose release" do
-    Rack::Contrib.must_respond_to(:release)
-  end
-end


### PR DESCRIPTION
This fixes issue #125 as described there.
