### PR TITLE
Adapt to ACCEPT_LANGUAGE="en-us" from Safari

### DIFF
--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -75,6 +75,17 @@ begin
         response_with_languages('ch,en;q=0.9').body.must_equal('ch')
       end
     end
+
+    specify 'should pick the available language' do
+      enforce_available_locales(false) do
+        response_with_languages('en-us').body.must_equal('en-us')
+      end
+    end
+    specify 'should pick the available closest language' do
+      enforce_available_locales(true) do
+        response_with_languages('en-us').body.must_equal('en')
+      end
+    end
   end
 rescue LoadError
   STDERR.puts "WARN: Skipping Rack::Locale tests (i18n not installed)"


### PR DESCRIPTION
Safari 10.1.2 (10603.3.8) on OSX Yosemite 10.10.5 (14F2411)

`env["HTTP_ACCEPT_LANGUAGE"]` yielding "en-us" makes rack/locale go

```
NoMethodError: undefined method `first' for nil:NilClass
    /Users/jmettraux/w/rack-contrib/lib/rack/contrib/locale.rb:43:in `accept_locale'
    /Users/jmettraux/w/rack-contrib/lib/rack/contrib/locale.rb:13:in `call'
    /Users/jmettraux/.gem/ruby/2.3.4/gems/rack-1.6.8/lib/rack/builder.rb:153:in `call'
    /Users/jmettraux/.gem/ruby/2.3.4/gems/rack-1.6.8/lib/rack/mock.rb:74:in `request'
    /Users/jmettraux/.gem/ruby/2.3.4/gems/rack-1.6.8/lib/rack/mock.rb:56:in `get'
    test/spec_rack_locale.rb:24:in `response_with_languages'
    test/spec_rack_locale.rb:86:in `block (3 levels) in <main>'
    test/spec_rack_locale.rb:30:in `enforce_available_locales'
    test/spec_rack_locale.rb:85:in `block (2 levels) in <main>'
```