### PR TITLE
return 400 bad request when contradiction between body and type

### DIFF
--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -34,7 +34,12 @@ module Rack
         env.update(FORM_HASH => JSON.parse(body, :create_additions => false), FORM_INPUT => env[POST_BODY])
       end
       @app.call(env)
+    rescue JSON::ParserError
+      bad_request('Bad Request (JSON::ParserError)')
     end
 
+    def bad_request(body = 'Bad Request')
+      [ 400, { 'Content-Type' => 'text/plain', 'Content-Length' => body.size.to_s }, [body] ]
+    end
   end
 end

--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -35,7 +35,7 @@ module Rack
       end
       @app.call(env)
     rescue JSON::ParserError
-      bad_request('Bad Request (JSON::ParserError)')
+      bad_request('failed to parse body as JSON')
     end
 
     def bad_request(body = 'Bad Request')

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -33,6 +33,23 @@ begin
       result.must_be_empty
     end
 
+    describe "contradiction between body and type" do
+      def assert_bad_request(response, err_class)
+        response.wont_equal nil
+        status, headers, body = response
+        status.must_equal 400
+        body.must_equal ["Bad Request (#{err_class})"]
+      end
+
+      specify "should return bad request with invalid JSON" do
+        test_body = '"bar":"foo"}'
+        env = Rack::MockRequest.env_for "/", {:method => "POST", :input => test_body, "CONTENT_TYPE" => 'application/json'}
+        app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST] }
+        response = Rack::PostBodyContentTypeParser.new(app).call(env)
+
+        assert_bad_request(response, JSON::ParserError)
+      end
+    end
   end
 
   def params_for_request(body, content_type)

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -15,7 +15,7 @@ begin
       params = params_for_request '{"key":"value"}', "application/json; charset=utf-8"
       params['key'].must_equal "value"
     end
-    
+
     specify "should parse 'application/json' requests with empty body" do
       params = params_for_request "", "application/json"
       params.must_equal({})
@@ -34,7 +34,7 @@ begin
     end
 
     describe "contradiction between body and type" do
-      def assert_failed_to_parse_as_json(response, err_class)
+      def assert_failed_to_parse_as_json(response)
         response.wont_equal nil
         status, headers, body = response
         status.must_equal 400
@@ -47,7 +47,7 @@ begin
         app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST] }
         response = Rack::PostBodyContentTypeParser.new(app).call(env)
 
-        assert_failed_to_parse_as_json(response, JSON::ParserError)
+        assert_failed_to_parse_as_json(response)
       end
     end
   end
@@ -57,7 +57,7 @@ begin
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST] }
     Rack::PostBodyContentTypeParser.new(app).call(env).last
   end
-  
+
 rescue LoadError => e
   # Missing dependency JSON, skipping tests.
   STDERR.puts "WARN: Skipping Rack::PostBodyContentTypeParser tests (json not installed)"

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -34,11 +34,11 @@ begin
     end
 
     describe "contradiction between body and type" do
-      def assert_bad_request(response, err_class)
+      def assert_failed_to_parse_as_json(response, err_class)
         response.wont_equal nil
         status, headers, body = response
         status.must_equal 400
-        body.must_equal ["Bad Request (#{err_class})"]
+        body.must_equal ["failed to parse body as JSON"]
       end
 
       specify "should return bad request with invalid JSON" do
@@ -47,7 +47,7 @@ begin
         app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST] }
         response = Rack::PostBodyContentTypeParser.new(app).call(env)
 
-        assert_bad_request(response, JSON::ParserError)
+        assert_failed_to_parse_as_json(response, JSON::ParserError)
       end
     end
   end


### PR DESCRIPTION
PostBodyContentTypeParser will stop at 500 error if body and content-type are inconsistent.

e.g. POST as `content-type=application/json` but passed body `foobar`.

With this pull request, set the response to 400 and tell the client that the cause of the error is in the request.