### PR TITLE
Replace regex without catastrophic backtracking

### DIFF
--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -7,8 +7,7 @@ module Rack
   class JSONP
     include Rack::Utils
 
-    VALID_JS_VAR    = /[a-zA-Z_$][\w$]*/
-    VALID_CALLBACK  = /\A#{VALID_JS_VAR}(?:\.?#{VALID_JS_VAR})*\z/
+    VALID_CALLBACK = /\A[a-zA-Z_$](?:\.?[\w$])*\z/
 
     # These hold the Unicode characters \u2028 and \u2029.
     #


### PR DESCRIPTION
The current regex for valid callbacks suffers from [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html). It is all good if the input string is a valid one. But, if an invalid character is included, it becomes very slow to compute.

These are some tests with invalid inputs comprised of valid characters and an invalid one at the last character. This is all in function of the length of the ok characters' string:

```ruby
require 'benchmark/ips'

ALLOWED_CHARS =  ('A'..'Z').to_a + ('a'..'z').to_a + ('0'..'9').to_a + %w(. _)

VALID_JS_VAR    = /[a-zA-Z_$][\w$]*/
VALID_CALLBACK  = /\A#{VALID_JS_VAR}(?:\.?#{VALID_JS_VAR})*\z/

Benchmark.ips do |x|
  (1..30).each do |i|
    string = ALLOWED_CHARS.take(i).join + '"'

    x.report("old #{i}") { string =~ VALID_CALLBACK }

    x.compare!
  end
end
```

```bash
$ ruby test.rb
Comparison:
        old 1:  3614796.8 i/s
        old 2:  3262514.1 i/s - 1.11x  slower
        old 3:  2558924.0 i/s - 1.41x  slower
        old 4:  1766859.1 i/s - 2.05x  slower
        old 5:  1110592.1 i/s - 3.25x  slower
        old 6:   629055.9 i/s - 5.75x  slower
        old 7:   337605.3 i/s - 10.71x  slower
        old 8:   174409.8 i/s - 20.73x  slower
        old 9:    88681.9 i/s - 40.76x  slower
       old 10:    45032.2 i/s - 80.27x  slower
       old 11:    22647.6 i/s - 159.61x  slower
       old 12:    11161.0 i/s - 323.88x  slower
       old 13:     5417.2 i/s - 667.28x  slower
       old 14:     2699.3 i/s - 1339.15x  slower
       old 15:     1316.6 i/s - 2745.61x  slower
       old 16:      706.3 i/s - 5118.07x  slower
       old 17:      354.6 i/s - 10193.10x  slower
       old 18:      178.6 i/s - 20240.66x  slower
       old 19:       89.4 i/s - 40443.26x  slower
       old 20:       44.8 i/s - 80653.97x  slower
       old 21:       22.5 i/s - 160999.51x  slower
       old 22:       11.3 i/s - 321218.80x  slower
       old 23:        5.6 i/s - 644808.38x  slower
       old 24:        2.8 i/s - 1294886.07x  slower
       old 25:        1.4 i/s - 2603385.92x  slower
       old 26:        0.7 i/s - 5156337.07x  slower
       old 27:        0.3 i/s - 10405761.68x  slower
       old 28:        0.2 i/s - 20648231.81x  slower
       old 29:        0.1 i/s - 45067939.73x  slower
       old 30:        0.0 i/s - 96287062.16x  slower
```

With the new regex:
```ruby
require 'benchmark/ips'

ALLOWED_CHARS =  ('A'..'Z').to_a + ('a'..'z').to_a + ('0'..'9').to_a + %w(. _)

NEW_REGEX = /\A[a-zA-Z_$](?:\.?[\w$])*\z/

Benchmark.ips do |x|
  (1..30).each do |i|
    string = ALLOWED_CHARS.take(i).join + '"'

    x.report("new #{i}") { string =~ NEW_REGEX }

    x.compare!
  end
end
```

```bash
$ ruby test.rb
Comparison:
               new 1:  3588834.1 i/s
               new 2:  3495103.3 i/s - same-ish: difference falls within error
               new 3:  3375242.2 i/s - same-ish: difference falls within error
               new 4:  3188470.0 i/s - 1.13x  slower
               new 5:  3118379.4 i/s - 1.15x  slower
               new 7:  2897696.2 i/s - 1.24x  slower
               new 6:  2787204.0 i/s - 1.29x  slower
               new 8:  2628809.4 i/s - 1.37x  slower
               new 9:  2508963.9 i/s - 1.43x  slower
              new 10:  2471942.5 i/s - 1.45x  slower
              new 11:  2384146.3 i/s - 1.51x  slower
              new 12:  2344501.6 i/s - 1.53x  slower
              new 13:  2266802.3 i/s - 1.58x  slower
              new 14:  2238924.4 i/s - 1.60x  slower
              new 16:  2094438.1 i/s - 1.71x  slower
              new 15:  2090429.5 i/s - 1.72x  slower
              new 17:  2004396.1 i/s - 1.79x  slower
              new 18:  2000011.7 i/s - 1.79x  slower
              new 20:  1922517.9 i/s - 1.87x  slower
              new 21:  1899221.2 i/s - 1.89x  slower
              new 19:  1890637.9 i/s - 1.90x  slower
              new 22:  1875959.5 i/s - 1.91x  slower
              new 23:  1806629.0 i/s - 1.99x  slower
              new 24:  1792349.6 i/s - 2.00x  slower
              new 25:  1757240.3 i/s - 2.04x  slower
              new 26:  1695242.6 i/s - 2.12x  slower
              new 27:  1686317.7 i/s - 2.13x  slower
              new 28:  1606692.2 i/s - 2.23x  slower
              new 30:  1552918.5 i/s - 2.31x  slower
              new 29:  1548472.7 i/s - 2.32x  slower
```