### PR TITLE
Rack::Locale use default_locale if none matches

### DIFF
--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -32,7 +32,7 @@ module Rack
         l.split(';q=')
       }
 
-      lang = languages_and_qvalues.sort_by { |(locale, qvalue)|
+      language_and_qvalue = languages_and_qvalues.sort_by { |(locale, qvalue)|
         qvalue.to_f
       }.reverse.detect { |(locale, qvalue)|
         if I18n.enforce_available_locales
@@ -40,8 +40,9 @@ module Rack
         else
           true
         end
-      }.first
+      }
 
+      lang = language_and_qvalue && language_and_qvalue.first
       lang == '*' ? nil : lang
     end
   end

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -37,11 +37,6 @@ begin
       response_with_languages(nil).body.must_equal('zh')
     end
 
-    specify 'should use I18n.default_locale if no languages are matched' do
-      I18n.default_locale = :zh
-      response_with_languages('ja').body.must_equal('zh')
-    end
-
     specify 'should treat an empty qvalue as 1.0' do
       response_with_languages('en,es;q=0.95').body.must_equal('en')
     end
@@ -72,6 +67,13 @@ begin
     specify 'should pick the available language' do
       enforce_available_locales(true) do
         response_with_languages('ch,en;q=0.9,es;q=0.95').body.must_equal('es')
+      end
+    end
+
+    specify 'should use default_locale if there is no matching language while enforcing available_locales' do
+      I18n.default_locale = :zh
+      enforce_available_locales(true) do
+        response_with_languages('ja').body.must_equal('zh')
       end
     end
 

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -37,6 +37,11 @@ begin
       response_with_languages(nil).body.must_equal('zh')
     end
 
+    specify 'should use I18n.default_locale if no languages are matched' do
+      I18n.default_locale = :zh
+      response_with_languages('ja').body.must_equal('zh')
+    end
+
     specify 'should treat an empty qvalue as 1.0' do
       response_with_languages('en,es;q=0.95').body.must_equal('en')
     end


### PR DESCRIPTION
Address #135 . Currently an Undefined method raises if none of Accept-Language matches to I18n.available_locales.