### PR TITLE
Fix a failing test

### DIFF
--- a/test/spec_rack_cookies.rb
+++ b/test/spec_rack_cookies.rb
@@ -52,9 +52,6 @@ describe "Rack::Cookies" do
     response = Rack::MockRequest.new(app).get('/', 'HTTP_COOKIE' => 'foo=bar;quux=h&m')
     response.body.must_equal('foo: , quux: h&m')
     response.headers['Set-Cookie'].must_match(/foo=(;|$)/)
-# This test is currently failing; I suspect it is due to a bug in a dependent
-# lib's cookie handling code, but I haven't had time to track it down yet
-#      -- @mpalmer, 2015-06-17
-#    response.headers['Set-Cookie'].must_match(/expires=Thu, 01 Jan 1970 00:00:00 GMT/)
+    response.headers['Set-Cookie'].must_match(/expires=Thu, 01 Jan 1970 00:00:00 -0000/)
   end
 end


### PR DESCRIPTION
Removing the timezone name `GMT` makes the test pass because `Time.at` does not return timezone name but offset value.
[Here](https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L303) is where `expires` value generated.

```ruby
Time.at(0)   # => 1970-01-01 09:00:00 +0900
```
[Time.at](https://ruby-doc.org/core-2.4.0/Time.html#method-c-at)