### PR TITLE
Misspellings: fixed

### DIFF
--- a/lib/rack/contrib/mailexceptions.rb
+++ b/lib/rack/contrib/mailexceptions.rb
@@ -90,7 +90,7 @@ module Rack
         mail.delivery_method :test
       elsif config[:smtp]
         smtp = config[:smtp]
-        # for backward compability, replace the :server key with :address
+        # for backward compatibility, replace the :server key with :address
         address = smtp.delete :server
         smtp[:address] = address if address
         mail.delivery_method :smtp, smtp

--- a/lib/rack/contrib/response_cache.rb
+++ b/lib/rack/contrib/response_cache.rb
@@ -23,7 +23,7 @@ class Rack::ResponseCache
     end
   end
 
-  # Initialize a new ReponseCache object with the given arguments.  Arguments:
+  # Initialize a new ResponseCache object with the given arguments.  Arguments:
   # * app : The next middleware in the chain.  This is always called.
   # * cache : The place to cache responses.  If a string is provided, a disk
   #   cache is used, and all cached files will use this directory as the root directory.
@@ -42,7 +42,7 @@ class Rack::ResponseCache
   # Call the next middleware with the environment.  If the request was successful (response status 200),
   # was a GET request, and had an empty query string, call the block set up in initialize to get the path.
   # If the cache is a string, create any necessary middle directories, and cache the file in the appropriate
-  # subdirectory of cache.  Otherwise, cache the body of the reponse as the value with the path as the key.
+  # subdirectory of cache.  Otherwise, cache the body of the response as the value with the path as the key.
   def call(env)
     res = @app.call(env)
     if env['REQUEST_METHOD'] == 'GET' and env['QUERY_STRING'] == '' and res[0] == 200 and path = @path_proc.call(env, res)

--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -16,7 +16,7 @@ module Rack
   #
   # Another way to bypass the cache is adding the version number in a field-value pair in the
   # URL query string. As an example, http://yoursite.com/images/test.png?v=1.0.0
-  # In that case, set the option :versioning to false to avoid unneccessary regexp calculations.
+  # In that case, set the option :versioning to false to avoid unnecessary regexp calculations.
   #
   # It's better to keep the current version number in some config file and use it in every static
   # content's URL. So each time we modify our static contents, we just have to change the version
@@ -40,7 +40,7 @@ module Rack
   #     default headers.
   #
   #     use Rack::StaticCache, :urls => ["/images"], :duration => 2, :versioning => false
-  #     will serve all requests begining with /images under the current directory (default for the option :root
+  #     will serve all requests beginning with /images under the current directory (default for the option :root
   #     is current directory). All the contents served will have cache expiration duration set to 2 years in headers
   #     (default for :duration is 1 year), and StaticCache will not compute any versioning logics (default for
   #     :versioning is true)

--- a/test/spec_rack_response_cache.rb
+++ b/test/spec_rack_response_cache.rb
@@ -56,7 +56,7 @@ describe Rack::ResponseCache do
     @cache.must_equal('/index.html'=>@def_value)
   end
 
-  specify "should not cache results if the request is not sucessful (status 200)" do
+  specify "should not cache results if the request is not successful (status 200)" do
     request{|env| [404, {'Content-Type' => 'text/html'}, ['']]}
     @cache.must_equal({})
     request{|env| [500, {'Content-Type' => 'text/html'}, ['']]}


### PR DESCRIPTION
This PR updates a few mis-spellings.

```
$ find . | misspellings -f -
./lib/rack/contrib/mailexceptions.rb:93: compability -> "compatibility"
./lib/rack/contrib/response_cache.rb:26: Reponse -> "Response"
./lib/rack/contrib/response_cache.rb:45: reponse -> "response"
./lib/rack/contrib/static_cache.rb:19: unneccessary -> "unnecessary"
./lib/rack/contrib/static_cache.rb:43: begining -> "beginning"
./test/spec_rack_response_cache.rb:59: sucessful -> "successful"
```