### PR TITLE
Correct Content-Length bug of Rack::NotFound

### DIFF
--- a/lib/rack/contrib/not_found.rb
+++ b/lib/rack/contrib/not_found.rb
@@ -19,7 +19,7 @@ module Rack
       else
         @content = F.read(path)
       end
-      @length = @content.size.to_s
+      @length = @content.bytesize.to_s
 
       @content_type = content_type
     end

--- a/test/spec_rack_not_found.rb
+++ b/test/spec_rack_not_found.rb
@@ -1,6 +1,7 @@
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/not_found'
+require 'tempfile'
 
 describe "Rack::NotFound" do
 
@@ -40,4 +41,18 @@ describe "Rack::NotFound" do
     response.status.must_equal(404)
   end
 
+  specify "should return correct size" do
+    Tempfile.open('test') do |f|
+      f.write '<!DOCTYPE html>'
+      f.write '<meta charset=utf-8>'
+      f.write '☃ snowman'
+      f.close
+      app = Rack::Builder.new do
+        use Rack::Lint
+        run Rack::NotFound.new(f.path)
+      end
+      response = Rack::MockRequest.new(app).get('/')
+      response.headers['Content-Length'].must_equal('46')
+    end
+  end
 end


### PR DESCRIPTION
This resolves #143 

As noted in the issue, Rack::NotFound is not returning the correct content-length when multibyte characters are involved.  This fixes it as suggested by @znz 

Failing test is included.