### PR TITLE
update rubies in travis configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8
 
 gemfile:
   - Gemfile


### PR DESCRIPTION
This bumps the versions of ruby that travis uses to test.

FWIW I attempted testing against ruby-head as well (since 2.5 should be out soon) but something farther up the stack throws errors.  I'll try to figure that out and PR something separately.