### PR TITLE
Removing has_rdoc deprecation warning

### DIFF
--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -52,7 +52,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc', '~> 5.0'
   s.add_development_dependency 'ruby-prof', '~> 0.17'
 
-  s.has_rdoc = true
   s.homepage = "https://github.com/rack/rack-contrib/"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "rack-contrib", "--main", "README"]
   s.require_paths = %w[lib]


### PR DESCRIPTION
Right now, every single time we install the gem, we got a warning:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```
this PR just remove the `has_rdoc` assignment to kill the warn message