### PR TITLE
Travis: update MRI versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: ruby
-sudo: false
+
 cache: bundler
 
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
   - 2.2.10
 
 gemfile:


### PR DESCRIPTION
This PR updates the Ruby versions in the CI matrix.

It also removes an unused Travis setting (sudo: false).