### PR TITLE
Use bytesize instead of size for Content-Length (fixes #148)

### DIFF
--- a/lib/rack/contrib/csshttprequest.rb
+++ b/lib/rack/contrib/csshttprequest.rb
@@ -31,7 +31,7 @@ module Rack
     end
 
     def modify_headers!(headers, encoded_response)
-      headers['Content-Length'] = encoded_response.length.to_s
+      headers['Content-Length'] = encoded_response.bytesize.to_s
       headers['Content-Type'] = 'text/css'
       nil
     end

--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -106,7 +106,7 @@ module Rack
     end
 
     def bad_request(body = "Bad Request")
-      [ 400, { 'Content-Type' => 'text/plain', 'Content-Length' => body.size.to_s }, [body] ]
+      [ 400, { 'Content-Type' => 'text/plain', 'Content-Length' => body.bytesize.to_s }, [body] ]
     end
 
   end

--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -40,7 +40,7 @@ module Rack
     end
 
     def bad_request(body = 'Bad Request')
-      [ 400, { 'Content-Type' => 'text/plain', 'Content-Length' => body.size.to_s }, [body] ]
+      [ 400, { 'Content-Type' => 'text/plain', 'Content-Length' => body.bytesize.to_s }, [body] ]
     end
   end
 end


### PR DESCRIPTION
I'm working on a performance improvement to PostBodyContentTypeParser, and figured I should close #148 before I submit any further changes.