### PR TITLE
Make PostBodyContentTypeParser 1.5x - 10x faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ interface:
 * `Rack::MailExceptions` - Rescues exceptions raised from the app and sends a useful email with the exception, stacktrace, and contents of the environment.
 * `Rack::NestedParams` - parses form params with subscripts (e.g., * "`post[title]=Hello`") into a nested/recursive Hash structure (based on Rails' implementation).
 * `Rack::NotFound` - A default 404 application.
-* `Rack::PostBodyContentTypeParser` - Adds support for JSON request bodies. The Rack parameter hash is populated by deserializing the JSON data provided in the request body when the Content-Type is application/json.
+* `Rack::PostBodyContentTypeParser` - Adds support for JSON request bodies. The Rack parameter hash is populated by deserializing the JSON data provided in the request body when the Content-Type includes `json`.
 * `Rack::Printout` - Prints the environment and the response per request
 * `Rack::ProcTitle` - Displays request information in process title (`$0`) for monitoring/inspection with ps(1).
 * `Rack::Profiler` - Uses ruby-prof to measure request time.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ interface:
 * `Rack::Deflect` - Helps protect against DoS attacks.
 * `Rack::Evil` - Lets the rack application return a response to the client from any place.
 * `Rack::HostMeta` - Configures `/host-meta` using a block
+* `Rack::JSONBodyParser` - Adds JSON request bodies to the Rack parameters hash.
 * `Rack::JSONP` - Adds JSON-P support by stripping out the callback param and padding the response with the appropriate callback format.
 * `Rack::LazyConditionalGet` - Caches a global `Last-Modified` date and updates it each time there is a request that is not `GET` or `HEAD`.
 * `Rack::LighttpdScriptNameFix` - Fixes how lighttpd sets the `SCRIPT_NAME` and `PATH_INFO` variables in certain configurations.
@@ -20,7 +21,7 @@ interface:
 * `Rack::MailExceptions` - Rescues exceptions raised from the app and sends a useful email with the exception, stacktrace, and contents of the environment.
 * `Rack::NestedParams` - parses form params with subscripts (e.g., * "`post[title]=Hello`") into a nested/recursive Hash structure (based on Rails' implementation).
 * `Rack::NotFound` - A default 404 application.
-* `Rack::PostBodyContentTypeParser` - Adds support for JSON request bodies. The Rack parameter hash is populated by deserializing the JSON data provided in the request body when the Content-Type includes `json`.
+* `Rack::PostBodyContentTypeParser` - [Deprecated]: Adds support for JSON request bodies. The Rack parameter hash is populated by deserializing the JSON data provided in the request body when the Content-Type is application/json
 * `Rack::Printout` - Prints the environment and the response per request
 * `Rack::ProcTitle` - Displays request information in process title (`$0`) for monitoring/inspection with ps(1).
 * `Rack::Profiler` - Uses ruby-prof to measure request time.

--- a/lib/rack/contrib.rb
+++ b/lib/rack/contrib.rb
@@ -24,6 +24,7 @@ module Rack
   autoload :HostMeta,                   "rack/contrib/host_meta"
   autoload :GarbageCollector,           "rack/contrib/garbagecollector"
   autoload :JSONP,                      "rack/contrib/jsonp"
+  autoload :JSONBodyParser,             "rack/contrib/json_body_parser"
   autoload :LazyConditionalGet,         "rack/contrib/lazy_conditional_get"
   autoload :LighttpdScriptNameFix,      "rack/contrib/lighttpd_script_name_fix"
   autoload :Locale,                     "rack/contrib/locale"

--- a/lib/rack/contrib/json_body_parser.rb
+++ b/lib/rack/contrib/json_body_parser.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Rack
+  # A Rack middleware for making JSON-encoded request bodies available in the
+  # request.params hash. By default it parses POST, PATCH, and PUT requests,
+  # but you can configure it to parse any request type via the :verbs option.
+  #
+  # Examples:
+  #     # parse POST and GET requests only
+  #     use Rack::JSONBodyParser, verbs: %w[POST GET]
+  #
+  #     # parse any request with 'json' in the Content-Type header
+  #     use Rack::JSONBodyParser, media_type_matcher: 'loose'
+  class JSONBodyParser
+    DEFAULT_VERBS = %w[POST PATCH PUT].freeze
+    DEFAULT_JSON_PARSER = ->(body) { JSON.parse(body, create_additions: false) }
+
+    def initialize(app, config = {}, &json_parser)
+      @app = app
+      @verbs = config[:verbs] || DEFAULT_VERBS
+      @media_matcher = MediaTypeMatchers.find(config[:media_type_matcher])
+      @json_parser = json_parser || DEFAULT_JSON_PARSER
+    end
+
+    def call(env)
+      if @verbs.include?(env[Rack::REQUEST_METHOD]) && @media_matcher.call(env)
+
+        write_json_body_to(env)
+      end
+      @app.call(env)
+    rescue JSON::ParserError
+      Rack::Response.new('failed to parse body as JSON', 400).finish
+    end
+
+    private
+
+    def write_json_body_to(env)
+      body = env[Rack::RACK_INPUT]
+      return unless (body_content = body.read) && !body_content.empty?
+
+      body.rewind # somebody might try to read this stream
+      env.update(
+        Rack::RACK_REQUEST_FORM_HASH => @json_parser.call(body_content),
+        Rack::RACK_REQUEST_FORM_INPUT => body
+      )
+    end
+
+    # Strategies for deciding whether a request counts as JSON
+    module MediaTypeMatchers
+      def self.find(matcher)
+        # if the matcher is callable, call it
+        return matcher if matcher.respond_to?(:call)
+
+        MATCHERS.fetch(matcher.to_s.to_sym, MATCHERS[:strict])
+      end
+
+      # Match any Content-Type header that includes "json"
+      module Loose
+        # Backport Ruby 2.4's regexp matcher, so Ruby >= 2.4 runs at top speed
+        unless ''.respond_to?(:match?)
+          refine String do
+            def match?(regex)
+              self =~ regex
+            end
+          end
+        end
+
+        # env['CONTENT_TYPE'] can be nil, so nil must handle #match?
+        refine NilClass do
+          def match?(_)
+            false
+          end
+        end
+
+        using self
+
+        def self.call(env)
+          env['CONTENT_TYPE'].match?(/json/o)
+        end
+      end
+
+      # Match only "application/json", "application/json; charset=utf-8", etc
+      module Strict
+        def self.call(env)
+          Rack::MediaType.type(env['CONTENT_TYPE']) == 'application/json'
+        end
+      end
+
+      MATCHERS = { strict: Strict, loose: Loose }.freeze
+    end
+
+    private_constant :MediaTypeMatchers
+  end
+end

--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -1,70 +1,46 @@
 begin
   require 'json'
-rescue LoadError
+rescue LoadError => e
   require 'json/pure'
 end
 
 module Rack
-  # A Rack middleware for making JSON-encoded request bodies available in the
-  # request.params hash. By default it parses POST, PATCH, and PUT requests,
-  # but you can configure it to parse any request type via the :verbs option
+
+  # A Rack middleware for parsing POST/PUT body data when Content-Type is
+  # not one of the standard supported types, like <tt>application/json</tt>.
   #
-  # Examples:
-  #     use Rack::PostBodyContentTypeParser, verbs: %w[POST GET]
+  # TODO: Find a better name.
+  #
   class PostBodyContentTypeParser
+
+    # Constants
+    #
     CONTENT_TYPE = 'CONTENT_TYPE'.freeze
-    DEFAULT_VERBS = %w[POST PATCH PUT].freeze
-    JSON_CONTENT_TYPE = /json/.freeze
-    DEFAULT_JSON_PARSER = ->(body) { JSON.parse(body, create_additions: false) }
+    POST_BODY = 'rack.input'.freeze
+    FORM_INPUT = 'rack.request.form_input'.freeze
+    FORM_HASH = 'rack.request.form_hash'.freeze
 
-    module Matchers
-      # Backport Ruby 2.4's regexp matcher, so Ruby >= 2.4 runs at top speed
-      unless ''.respond_to?(:match?)
-        refine String do
-          def match?(regex)
-            self =~ regex
-          end
-        end
-      end
+    # Supported Content-Types
+    #
+    APPLICATION_JSON = 'application/json'.freeze
 
-      # env[CONTENT_TYPE] can be nil, so nil must handle #match? in this scope
-      refine NilClass do
-        def match?(_)
-          false
-        end
-      end
-    end
-
-    using Matchers
-
-    def initialize(app, config = {}, &json_parser)
+    def initialize(app, &block)
       @app = app
-      @verbs = config[:verbs] || DEFAULT_VERBS
-      @json_parser = json_parser || DEFAULT_JSON_PARSER
+      @block = block || Proc.new { |body| JSON.parse(body, :create_additions => false) }
     end
 
     def call(env)
-      if @verbs.include?(env[Rack::REQUEST_METHOD]) &&
-         env[CONTENT_TYPE].match?(JSON_CONTENT_TYPE)
-
-        write_json_body_to(env)
+      if Rack::Request.new(env).media_type == APPLICATION_JSON && (body = env[POST_BODY].read).length != 0
+        env[POST_BODY].rewind # somebody might try to read this stream
+        env.update(FORM_HASH => @block.call(body), FORM_INPUT => env[POST_BODY])
       end
       @app.call(env)
     rescue JSON::ParserError
-      Rack::Response.new('failed to parse body as JSON', 400).finish
+      bad_request('failed to parse body as JSON')
     end
 
-    private
-
-    def write_json_body_to(env)
-      body = env[Rack::RACK_INPUT]
-      return unless (body_content = body.read) && !body_content.empty?
-
-      body.rewind # somebody might try to read this stream
-      env.update(
-        Rack::RACK_REQUEST_FORM_HASH => @json_parser.call(body_content),
-        Rack::RACK_REQUEST_FORM_INPUT => body
-      )
+    def bad_request(body = 'Bad Request')
+      [ 400, { 'Content-Type' => 'text/plain', 'Content-Length' => body.bytesize.to_s }, [body] ]
     end
   end
 end

--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -6,11 +6,10 @@ end
 
 module Rack
 
+  # <b>DEPRECATED:</b> <tt>JSONBodyParser</tt> is a drop-in replacement that is faster and more configurable.
+  #
   # A Rack middleware for parsing POST/PUT body data when Content-Type is
   # not one of the standard supported types, like <tt>application/json</tt>.
-  #
-  # TODO: Find a better name.
-  #
   class PostBodyContentTypeParser
 
     # Constants
@@ -25,6 +24,7 @@ module Rack
     APPLICATION_JSON = 'application/json'.freeze
 
     def initialize(app, &block)
+      warn "[DEPRECATION] `PostBodyContentTypeParser` is deprecated. Use `JSONBodyParser` as a drop-in replacement."
       @app = app
       @block = block || Proc.new { |body| JSON.parse(body, :create_additions => false) }
     end

--- a/test/spec_rack_json_body_parser_spec.rb
+++ b/test/spec_rack_json_body_parser_spec.rb
@@ -1,0 +1,114 @@
+require 'minitest/autorun'
+require 'rack/mock'
+require 'rack/contrib/json_body_parser'
+
+describe Rack::JSONBodyParser do
+  def app
+    ->(env) { Rack::Request.new(env).POST }
+  end
+
+  def echo(body, type:, verb: 'POST', parser: Rack::JSONBodyParser.new(app))
+    env = Rack::MockRequest.env_for '/', method: verb, input: body, 'CONTENT_TYPE' => type
+    parser.call(env)
+  end
+
+  specify "should parse 'application/json' requests" do
+    params = echo '{"key":"value"}', type: "application/json"
+    params['key'].must_equal "value"
+  end
+
+  specify "should parse 'application/json; charset=utf-8' requests" do
+    params = echo '{"key":"value"}', type: "application/json; charset=utf-8"
+    params['key'].must_equal "value"
+  end
+
+  specify "should parse 'application/json' requests with empty body" do
+    params = echo "", type: "application/json"
+    params.must_equal({})
+  end
+
+  specify "shouldn't affect form-urlencoded requests" do
+    params = echo "key=value", type: "application/x-www-form-urlencoded"
+    params['key'].must_equal "value"
+  end
+
+  specify "shouldn't parse or error when CONTENT_TYPE is nil" do
+    params = echo '{"key":"value"}', type: nil
+    assert_nil(params['key'])
+  end
+
+  specify "should not create additions" do
+    before = Symbol.all_symbols
+    echo %{{"json_class":"this_should_not_be_added"}}, type: "application/json"
+    result = Symbol.all_symbols - before
+    result.must_be_empty
+  end
+
+  specify "should apply given block to a JSON body" do
+    parser = Rack::JSONBodyParser.new(app) do |body|
+      { 'payload' => JSON.parse(body) }
+    end
+    params = echo '{"key":"value"}', type: "application/json", parser: parser
+    params['payload'].wont_be_nil
+    params['payload']['key'].must_equal "value"
+  end
+
+  describe "with a loose media_type_matcher" do
+    specify "should match any header containing 'json'" do
+      loose_parser = Rack::JSONBodyParser.new(app, media_type_matcher: :loose)
+      params = echo(
+        '{"key":"value"}',
+        type: "application/vnd.api+json",
+        parser: loose_parser
+      )
+      params['key'].must_equal "value"
+    end
+
+    specify "shouldn't parse or error when CONTENT_TYPE is nil" do
+      loose_parser = Rack::JSONBodyParser.new(app, media_type_matcher: :loose)
+      params = echo '{"key":"value"}', type: nil, parser: loose_parser
+      assert_nil(params['key'])
+    end
+  end
+
+  specify "should accept a custom media matcher callable" do
+    custom_parser = Rack::JSONBodyParser.new(
+      app,
+      media_type_matcher: ->(env) { env['CONTENT_TYPE'] == 'custom' }
+    )
+    params = echo '{"key":"value"}', type: 'custom', parser: custom_parser
+    params['key'].must_equal "value"
+  end
+
+  describe "should skip parsing for some HTTP verbs" do
+    body = '{"key":"value"}'
+
+    specify "should ignore GET|OPTIONS|HEAD|TRACE requests by default" do
+      %w[GET OPTIONS HEAD CONNECT TRACE].each do |verb|
+        params = echo body, type: 'application/json', verb: verb
+        assert_nil(params['key'])
+      end
+    end
+
+    specify "should allow overriding the HTTP verbs that get parsed" do
+      parser = Rack::JSONBodyParser.new(app, verbs: %w[DELETE])
+      params = echo body, type: 'application/json', verb: 'DELETE', parser: parser
+      params['key'].must_equal 'value'
+    end
+  end
+
+  describe "contradiction between body and type" do
+    def assert_failed_to_parse_as_json(response)
+      response.wont_be_nil
+      status, headers, body = response
+      status.must_equal 400
+      body.each { |part| part.must_equal "failed to parse body as JSON" }
+    end
+
+    specify "should return bad request with invalid JSON" do
+      test_body = '"bar":"foo"}'
+      response = echo test_body, type: 'application/json'
+      assert_failed_to_parse_as_json(response)
+    end
+  end
+end

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -16,11 +16,6 @@ begin
       params['key'].must_equal "value"
     end
 
-    specify "should parse application/vnd.api+json requests" do
-      params = params_for_request '{"key":"value"}', "application/vnd.api+json"
-      params['key'].must_equal "value"
-    end
-
     specify "should parse 'application/json' requests with empty body" do
       params = params_for_request "", "application/json"
       params.must_equal({})
@@ -29,11 +24,6 @@ begin
     specify "shouldn't affect form-urlencoded requests" do
       params = params_for_request("key=value", "application/x-www-form-urlencoded")
       params['key'].must_equal "value"
-    end
-
-    specify "shouldn't parse or error when CONTENT_TYPE is nil" do
-      params = params_for_request('{"key":"value"}', nil)
-      assert_nil(params['key'])
     end
 
     specify "should not create additions" do
@@ -51,31 +41,12 @@ begin
       params['payload']['key'].must_equal "value"
     end
 
-    describe "should skip parsing for some HTTP verbs" do
-      body = '{"key":"value"}'
-
-      specify "should ignore GET|OPTIONS|HEAD|TRACE requests by default" do
-        %w[GET OPTIONS HEAD CONNECT TRACE].each do |verb|
-          params = params_for_request(body, 'application/json', verb)
-          assert_nil(params['key'])
-        end
-      end
-
-      specify "should allow overriding the HTTP verbs that get parsed" do
-        app = ->(env) { Rack::Request.new(env).POST }
-        parser = Rack::PostBodyContentTypeParser.new(app, verbs: %w[DELETE])
-        env = Rack::MockRequest.env_for '/', method: 'DELETE', input: body, 'CONTENT_TYPE' => 'application/json'
-        params = parser.call(env)
-        params['key'].must_equal 'value'
-      end
-    end
-
     describe "contradiction between body and type" do
       def assert_failed_to_parse_as_json(response)
         response.wont_be_nil
         status, headers, body = response
         status.must_equal 400
-        body.each { |part| part.must_equal "failed to parse body as JSON" }
+        body.must_equal ["failed to parse body as JSON"]
       end
 
       specify "should return bad request with invalid JSON" do
@@ -89,8 +60,8 @@ begin
     end
   end
 
-  def params_for_request(body, content_type, method = "POST", &block)
-    env = Rack::MockRequest.env_for "/", {:method => method, :input => body, "CONTENT_TYPE" => content_type}
+  def params_for_request(body, content_type, &block)
+    env = Rack::MockRequest.env_for "/", {:method => "POST", :input => body, "CONTENT_TYPE" => content_type}
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST] }
     Rack::PostBodyContentTypeParser.new(app, &block).call(env).last
   end


### PR DESCRIPTION
This is a non-breaking (I hope!) refactor of PostBodyContentTypeParser, aimed at improving performance. It uses a couple of tactics to make things faster:

1. Skip parsing GET, OPTIONS and other bodiless HTTP requests by default. Because the HTTP spec disallows these request types from having a body, this change shouldn't affect anyone's app — although it is the change I'm most worried about. Seems worth the risk, though, because it improves performance of GET requests by 10x.

2. For POST, PATCH, and PUT requests, (a) read the content-type from `env` directly, instead of instantiating a `Rack::Request`, and (b) use Ruby 2.4's `String#match?` operator when available. These changes speed up the requests that do get parsed by 1.5x.

This PR also makes the middleware more liberal about what content-types it will accept. Instead of just `application/json`, it matches any content-type that includes `json`. I made this change because I want to support the JSON:API content-type: https://jsonapi.org/format/#content-negotiation-clients

If this PR gets merged, I figured it'd be on me to fix any bugs, so I prioritized making the code readable (to me) over minimizing the number of lines I changed. I'm happy to try again with an eye toward minimizing the diff, though, if that would be preferable to you @mpalmer.

Here's the benchmark I was running to measure performance changes:

```ruby
require 'bundler/setup'
require 'rack'
require 'rack/contrib'
require 'benchmark/ips'

App = Rack::Builder.new {
  use Rack::PostBodyContentTypeParser
  run lambda { |env| [200, { 'Content-Length' => '2' }, ['ok']] }
}.to_app

body = StringIO.new('{"key":"value"}')
config = { input: body, 'CONTENT_TYPE' => 'application/json' }
get_env = Rack::MockRequest.env_for('/', config)
post_env = Rack::MockRequest.env_for('/', config.merge(method: 'POST'))

Benchmark.ips do |bm|
  bm.report 'GET' do
    App.call(get_env)
  end

  bm.report 'POST' do
    App.call(post_env)
  end

  bm.compare!
end
```

I ran it first from the master branch and then again from my fork. Here are the results:

```
MASTER
Warming up --------------------------------------
        GET (master)    19.126k i/100ms
       POST (master)    19.025k i/100ms
Calculating -------------------------------------
        GET (master)    204.358k (± 4.3%) i/s -      1.033M in   5.064006s
       POST (master)    196.148k (± 4.0%) i/s -    989.300k in   5.051819s

Comparison:
        GET (master):   204358.1 i/s
       POST (master):   196147.9 i/s - same-ish: difference falls within error

PATCHED
Warming up --------------------------------------
       GET (patched)   135.596k i/100ms
      POST (patched)    26.123k i/100ms
Calculating -------------------------------------
       GET (patched)      2.137M (± 0.8%) i/s -     10.712M in   5.012443s
      POST (patched)    290.596k (± 1.7%) i/s -      1.463M in   5.035550s

Comparison:
       GET (patched):  2137227.5 i/s
      POST (patched):   290596.3 i/s - 7.35x  slower
```

As you can see, GET performance jumps from 200k IPS to 2M IPS, and POST performance jumps from 200K IPS to 290K IPS.