### PR TITLE
Documentation: add usage examples for PostBodyContentTypeParser

### DIFF
--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -11,6 +11,48 @@ module Rack
   #
   # TODO: Find a better name.
   #
+  #
+  # === How to use the middleware
+  #
+  # Example of simple +config.ru+ file:
+  #
+  #  require 'rack'
+  #  require 'rack/contrib'
+  #
+  #  use ::Rack::PostBodyContentTypeParser
+  #
+  #  app = lambda do |env|
+  #    request = Rack::Request.new(env)
+  #    body = "Hello #{request.params['name']}"
+  #    [200, {'Content-Type' => 'text/plain'}, [body]]
+  #  end
+  #
+  #  run app
+  #
+  # Example with passing block argument:
+  #
+  #   use ::Rack::PostBodyContentTypeParser do |body|
+  #     { 'params' => JSON.parse(body) }
+  #   end
+  #
+  # Example with passing proc argument:
+  #
+  #   parser = ->(body) { { 'params' => JSON.parse(body) } }
+  #   use ::Rack::PostBodyContentTypeParser, &parser
+  #
+  #
+  # === Failed JSON parsing
+  #
+  # Returns "400 Bad request" response if invalid JSON document was sent:
+  #
+  # Raw HTTP response:
+  #
+  #   HTTP/1.1 400 Bad Request
+  #   Content-Type: text/plain
+  #   Content-Length: 28
+  #
+  #   failed to parse body as JSON
+  #
   class PostBodyContentTypeParser
 
     # Constants


### PR DESCRIPTION
It's a common practice to accept block arguments in Rack middlewares.

So I just added examples of using the PostBodyContentTypeParser middleware
- w/o parameter
- w/ block parameter
- w/ converting `proc` to block parameter

Closes https://github.com/rack/rack-contrib/issues/162