### PR TITLE
Fix tests warnings and failures

### DIFF
--- a/test/spec_rack_access.rb
+++ b/test/spec_rack_access.rb
@@ -23,62 +23,62 @@ describe "Rack::Access" do
   specify "default configuration should deny non-local requests" do
     app = middleware
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
   end
 
   specify "default configuration should allow requests from 127.0.0.1" do
     app = middleware
     status, headers, body = app.call(mock_env(@mock_addr_localhost))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
   end
 
   specify "should allow remote addresses in allow_ipmasking" do
     app = middleware('/' => [@mock_addr_1])
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
   end
 
   specify "should deny remote addresses not in allow_ipmasks" do
     app = middleware('/' => [@mock_addr_1])
     status, headers, body = app.call(mock_env(@mock_addr_2))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
   end
 
   specify "should allow remote addresses in allow_ipmasks range" do
     app = middleware('/' => [@mock_addr_range])
     status, headers, body = app.call(mock_env(@mock_addr_2))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
   end
 
   specify "should deny remote addresses not in allow_ipmasks range" do
     app = middleware('/' => [@mock_addr_range])
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
   end
 
   specify "should allow remote addresses in one of allow_ipmasking" do
     app = middleware('/' => [@mock_addr_range, @mock_addr_localhost])
 
     status, headers, body = app.call(mock_env(@mock_addr_2))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_localhost))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
   end
 
   specify "should deny remote addresses not in one of allow_ipmasks" do
     app = middleware('/' => [@mock_addr_range, @mock_addr_localhost])
     status, headers, body = app.call(mock_env(@mock_addr_1))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
   end
 
   specify "handles paths correctly" do
@@ -89,66 +89,66 @@ describe "Rack::Access" do
     })
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/qux"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo"))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/"))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/bar"))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/bar"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
     status, headers, body = app.call(mock_env(@mock_addr_2, "/foo/bar"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/bar/"))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/bar/"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo///bar//quux"))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo///bar//quux"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/foo/quux"))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/foo/quux"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
 
     status, headers, body = app.call(mock_env(@mock_addr_1, "/bar"))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
     status, headers, body = app.call(mock_env(@mock_addr_1, "/bar").merge('HTTP_HOST' => 'foo.org'))
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
     status, headers, body = app.call(mock_env(@mock_addr_localhost, "/bar").merge('HTTP_HOST' => 'foo.org'))
-    status.must_equal 200
-    body.must_equal ['hello']
+    _(status).must_equal 200
+    _(body).must_equal ['hello']
   end
 end

--- a/test/spec_rack_backstage.rb
+++ b/test/spec_rack_backstage.rb
@@ -10,8 +10,8 @@ describe "Rack::Backstage" do
       run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal('Under maintenance.')
-    response.status.must_equal(503)
+    _(response.body).must_equal('Under maintenance.')
+    _(response.status).must_equal(503)
   end
 
   specify "passes on request if page is not present" do
@@ -20,7 +20,7 @@ describe "Rack::Backstage" do
       run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal('Hello, World!')
-    response.status.must_equal(200)
+    _(response.body).must_equal('Hello, World!')
+    _(response.status).must_equal(200)
   end
 end

--- a/test/spec_rack_bounce_favicon.rb
+++ b/test/spec_rack_bounce_favicon.rb
@@ -10,11 +10,11 @@ describe Rack::BounceFavicon do
 
   specify 'does nothing when requesting paths other than the favicon' do
     response = Rack::MockRequest.new(app).get('/')
-    response.status.must_equal(200)
+    _(response.status).must_equal(200)
   end
 
   specify 'gives a 404 when requesting the favicon' do
     response = Rack::MockRequest.new(app).get('/favicon.ico')
-    response.status.must_equal(404)
+    _(response.status).must_equal(404)
   end
 end

--- a/test/spec_rack_callbacks.rb
+++ b/test/spec_rack_callbacks.rb
@@ -56,11 +56,11 @@ describe "Rack::Callbacks" do
 
     response = Rack::MockRequest.new(app).get("/")
 
-    response.body.must_equal 'F Lifo..with love'
+    _(response.body).must_equal 'F Lifo..with love'
 
-    $old_status.must_equal 200
-    response.status.must_equal 201
+    _($old_status).must_equal 200
+    _(response.status).must_equal 201
 
-    response.headers['last'].must_equal 'TheEnd'
+    _(response.headers['last']).must_equal 'TheEnd'
   end
 end

--- a/test/spec_rack_common_cookies.rb
+++ b/test/spec_rack_common_cookies.rb
@@ -22,86 +22,86 @@ describe Rack::CommonCookies do
 
   specify 'should use .domain.com for cookies from domain.com' do
     response = make_request 'domain.com'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.com'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.com'
   end
 
   specify 'should use .domain.com for cookies from www.domain.com' do
     response = make_request 'www.domain.com'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.com'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.com'
   end
 
   specify 'should use .domain.com for cookies from subdomain.domain.com' do
     response = make_request 'subdomain.domain.com'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.com'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.com'
   end
 
   specify 'should use .domain.com for cookies from 0.subdomain1.subdomain2.domain.com' do
     response = make_request '0.subdomain1.subdomain2.domain.com'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.com'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.com'
   end
 
   specify 'should use .domain.local for cookies from domain.local' do
     response = make_request '0.subdomain1.subdomain2.domain.com'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.com'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.com'
   end
 
   specify 'should use .domain.local for cookies from subdomain.domain.local' do
     response = make_request 'subdomain.domain.local'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.local'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.local'
   end
 
   specify 'should use .domain.com.ua for cookies from domain.com.ua' do
     response = make_request 'domain.com.ua'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.com.ua'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.com.ua'
   end
 
   specify 'should use .domain.com.ua for cookies from subdomain.domain.com.ua' do
     response = make_request 'subdomain.domain.com.ua'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.com.ua'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.com.ua'
   end
 
   specify 'should use .domain.co.uk for cookies from domain.co.uk' do
     response = make_request 'domain.co.uk'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.co.uk'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.co.uk'
   end
 
   specify 'should use .domain.co.uk for cookies from subdomain.domain.co.uk' do
     response = make_request 'subdomain.domain.co.uk'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.co.uk'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.co.uk'
   end
 
   specify 'should use .domain.eu.com for cookies from domain.eu.com' do
     response = make_request 'domain.eu.com'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.eu.com'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.eu.com'
   end
 
   specify 'should use .domain.eu.com for cookies from subdomain.domain.eu.com' do
     response = make_request 'subdomain.domain.eu.com'
-    response.headers['Set-Cookie'].must_equal 'key=value; domain=.domain.eu.com'
+    _(response.headers['Set-Cookie']).must_equal 'key=value; domain=.domain.eu.com'
   end
 
   specify 'should work with multiple cookies' do
     response = make_request 'sub.domain.bz', "key=value\nkey1=value2"
-    response.headers['Set-Cookie'].must_equal "key=value; domain=.domain.bz\nkey1=value2; domain=.domain.bz"
+    _(response.headers['Set-Cookie']).must_equal "key=value; domain=.domain.bz\nkey1=value2; domain=.domain.bz"
   end
 
   specify 'should work with cookies which have explicit domain' do
     response = make_request 'sub.domain.bz', "key=value; domain=domain.bz"
-    response.headers['Set-Cookie'].must_equal "key=value; domain=.domain.bz"
+    _(response.headers['Set-Cookie']).must_equal "key=value; domain=.domain.bz"
   end
 
   specify 'should not touch cookies if domain is localhost' do
     response = make_request 'localhost'
-    response.headers['Set-Cookie'].must_equal "key=value"
+    _(response.headers['Set-Cookie']).must_equal "key=value"
   end
 
   specify 'should not touch cookies if domain is ip address' do
     response = make_request '127.0.0.1'
-    response.headers['Set-Cookie'].must_equal "key=value"
+    _(response.headers['Set-Cookie']).must_equal "key=value"
   end
 
   specify 'should use .domain.com for cookies from subdomain.domain.com:3000' do
     response = make_request 'subdomain.domain.com:3000'
-    response.headers['Set-Cookie'].must_equal "key=value; domain=.domain.com"
+    _(response.headers['Set-Cookie']).must_equal "key=value; domain=.domain.com"
   end
 end

--- a/test/spec_rack_config.rb
+++ b/test/spec_rack_config.rb
@@ -16,7 +16,7 @@ describe "Rack::Config" do
       }
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal('hello')
+    _(response.body).must_equal('hello')
   end
 
 end

--- a/test/spec_rack_contrib.rb
+++ b/test/spec_rack_contrib.rb
@@ -3,6 +3,6 @@ require 'rack/contrib'
 
 describe "Rack::Contrib" do
   specify "should expose release" do
-    Rack::Contrib.must_respond_to(:release)
+    _(Rack::Contrib).must_respond_to(:release)
   end
 end

--- a/test/spec_rack_cookies.rb
+++ b/test/spec_rack_cookies.rb
@@ -12,7 +12,7 @@ describe "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/', 'HTTP_COOKIE' => 'foo=bar;quux=h&m')
-    response.body.must_equal('foo: bar, quux: h&m')
+    _(response.body).must_equal('foo: bar, quux: h&m')
   end
 
   specify "should be able to set new cookies" do
@@ -25,7 +25,7 @@ describe "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/')
-    response.headers['Set-Cookie'].split("\n").sort.must_equal(["foo=bar; path=/","quux=h%26m; path=/"])
+    _(response.headers['Set-Cookie'].split("\n").sort).must_equal(["foo=bar; path=/","quux=h%26m; path=/"])
   end
 
   specify "should be able to set cookie with options" do
@@ -37,7 +37,7 @@ describe "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/')
-    response.headers['Set-Cookie'].must_equal('foo=bar; path=/login; secure')
+    _(response.headers['Set-Cookie']).must_equal('foo=bar; path=/login; secure')
   end
 
   specify "should be able to delete received cookies" do
@@ -50,8 +50,8 @@ describe "Rack::Cookies" do
     app = Rack::Cookies.new(app)
 
     response = Rack::MockRequest.new(app).get('/', 'HTTP_COOKIE' => 'foo=bar;quux=h&m')
-    response.body.must_equal('foo: , quux: h&m')
-    response.headers['Set-Cookie'].must_match(/foo=(;|$)/)
+    _(response.body).must_equal('foo: , quux: h&m')
+    _(response.headers['Set-Cookie']).must_match(/foo=(;|$)/)
 # This test is currently failing; I suspect it is due to a bug in a dependent
 # lib's cookie handling code, but I haven't had time to track it down yet
 #      -- @mpalmer, 2015-06-17

--- a/test/spec_rack_csshttprequest.rb
+++ b/test/spec_rack_csshttprequest.rb
@@ -18,21 +18,21 @@ begin
         PATH_INFO ends with '.chr'" do
       request = Rack::MockRequest.env_for("/blah.chr", :lint => true, :fatal => true)
       Rack::CSSHTTPRequest.new(@app).call(request)
-      request['csshttprequest.chr'].must_equal true
+      _(request['csshttprequest.chr']).must_equal true
     end
 
     specify "env['csshttprequest.chr'] should be set to true when \
         request parameter _format == 'chr'" do
       request = Rack::MockRequest.env_for("/?_format=chr", :lint => true, :fatal => true)
       Rack::CSSHTTPRequest.new(@app).call(request)
-      request['csshttprequest.chr'].must_equal true
+      _(request['csshttprequest.chr']).must_equal true
     end
 
     specify "should not change the headers or response when !env['csshttprequest.chr']" do
       request = Rack::MockRequest.env_for("/", :lint => true, :fatal => true)
       status, headers, response = Rack::CSSHTTPRequest.new(@app).call(request)
-      headers.must_equal @test_headers
-      response.join.must_equal @test_body
+      _(headers).must_equal @test_headers
+      _(response.join).must_equal @test_body
     end
 
     describe "when env['csshttprequest.chr']" do
@@ -43,17 +43,17 @@ begin
 
       specify "should modify the content length to the correct value" do
         headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
-        headers['Content-Length'].must_equal @encoded_body.length.to_s
+        _(headers['Content-Length']).must_equal @encoded_body.length.to_s
       end
 
       specify "should modify the content type to the correct value" do
         headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
-        headers['Content-Type'].must_equal 'text/css'
+        _(headers['Content-Type']).must_equal 'text/css'
       end
 
       specify "should not modify any other headers" do
         headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
-        headers.must_equal @test_headers.merge({
+        _(headers).must_equal @test_headers.merge({
           'Content-Type' => 'text/css',
           'Content-Length' => @encoded_body.length.to_s
         })

--- a/test/spec_rack_deflect.rb
+++ b/test/spec_rack_deflect.rb
@@ -22,8 +22,8 @@ describe "Rack::Deflect" do
   specify "should allow regular requests to follow through" do
     app = mock_deflect
     status, headers, body = app.call mock_env(@mock_addr_1)
-    status.must_equal 200
-    body.must_equal ['cookies']
+    _(status).must_equal 200
+    _(body).must_equal ['cookies']
   end
 
   specify "should deflect requests exceeding the request threshold" do
@@ -34,19 +34,19 @@ describe "Rack::Deflect" do
     # First 5 should be fine
     5.times do
       status, headers, body = app.call env
-      status.must_equal 200
-      body.must_equal ['cookies']
+      _(status).must_equal 200
+      _(body).must_equal ['cookies']
     end
 
     # Remaining requests should fail for 10 seconds
     10.times do
       status, headers, body = app.call env
-      status.must_equal 403
-      body.must_equal []
+      _(status).must_equal 403
+      _(body).must_equal []
     end
 
     # Log should reflect that we have blocked an address
-    log.string.must_match(/^deflect\(\d+\/\d+\/\d+\): blocked 111.111.111.111\n/)
+    _(log.string).must_match(/^deflect\(\d+\/\d+\/\d+\): blocked 111.111.111.111\n/)
   end
 
   specify "should expire blocking" do
@@ -57,27 +57,27 @@ describe "Rack::Deflect" do
     # First 5 should be fine
     5.times do
       status, headers, body = app.call env
-      status.must_equal 200
-      body.must_equal ['cookies']
+      _(status).must_equal 200
+      _(body).must_equal ['cookies']
     end
 
     # Exceeds request threshold
     status, headers, body = app.call env
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
 
     # Move to the future so the block will expire
     Time.stub :now, Time.now + 3 do
       # Another 5 is fine now
       5.times do
         status, headers, body = app.call env
-        status.must_equal 200
-        body.must_equal ['cookies']
+        _(status).must_equal 200
+        _(body).must_equal ['cookies']
       end
     end
 
     # Log should reflect block and release
-    log.string.must_match(/deflect.*: blocked 111\.111\.111\.111\ndeflect.*: released 111\.111\.111\.111\n/)
+    _(log.string).must_match(/deflect.*: blocked 111\.111\.111\.111\ndeflect.*: released 111\.111\.111\.111\n/)
   end
 
   specify "should allow whitelisting of remote addresses" do
@@ -87,8 +87,8 @@ describe "Rack::Deflect" do
     # Whitelisted addresses are always fine
     10.times do
       status, headers, body = app.call env
-      status.must_equal 200
-      body.must_equal ['cookies']
+      _(status).must_equal 200
+      _(body).must_equal ['cookies']
     end
   end
 
@@ -96,12 +96,12 @@ describe "Rack::Deflect" do
     app = mock_deflect :blacklist => [@mock_addr_2]
 
     status, headers, body = app.call mock_env(@mock_addr_1)
-    status.must_equal 200
-    body.must_equal ['cookies']
+    _(status).must_equal 200
+    _(body).must_equal ['cookies']
 
     status, headers, body = app.call mock_env(@mock_addr_2)
-    status.must_equal 403
-    body.must_equal []
+    _(status).must_equal 403
+    _(body).must_equal []
   end
 
 end

--- a/test/spec_rack_enforce_valid_encoding.rb
+++ b/test/spec_rack_enforce_valid_encoding.rb
@@ -19,39 +19,39 @@ if "a string".respond_to?(:valid_encoding?)
 
     describe "contstant assertions" do
       it "INVALID_PATH should not be a valid UTF-8 string when decoded" do
-        Rack::Utils.unescape(INVALID_PATH).valid_encoding?.must_equal false
+        _(Rack::Utils.unescape(INVALID_PATH).valid_encoding?).must_equal false
       end
 
       it "VALID_PATH should be valid when decoded" do
-        Rack::Utils.unescape(VALID_PATH).valid_encoding?.must_equal true
+        _(Rack::Utils.unescape(VALID_PATH).valid_encoding?).must_equal true
       end
     end
 
     it "should accept a request with a correctly encoded path" do
       response = Rack::MockRequest.new(@app).get(VALID_PATH)
-      response.body.must_equal("Hello World")
-      response.status.must_equal(200)
+      _(response.body).must_equal("Hello World")
+      _(response.status).must_equal(200)
     end
 
     it "should reject a request with a poorly encoded path" do
       response = Rack::MockRequest.new(@app).get(INVALID_PATH)
-      response.status.must_equal(400)
+      _(response.status).must_equal(400)
     end
 
     it "should accept a request with a correctly encoded query string" do
       response = Rack::MockRequest.new(@app).get('/', 'QUERY_STRING' => VALID_PATH)
-      response.body.must_equal("Hello World")
-      response.status.must_equal(200)
+      _(response.body).must_equal("Hello World")
+      _(response.status).must_equal(200)
     end
 
     it "should reject a request with a poorly encoded query string" do
       response = Rack::MockRequest.new(@app).get('/', 'QUERY_STRING' => INVALID_PATH)
-      response.status.must_equal(400)
+      _(response.status).must_equal(400)
     end
 
     it "should reject a request containing malformed multibyte characters" do
       response = Rack::MockRequest.new(@app).get('/', 'QUERY_STRING' => Rack::Utils.unescape(INVALID_PATH, Encoding::ASCII_8BIT))
-      response.status.must_equal(400)
+      _(response.status).must_equal(400)
     end
   end
 else

--- a/test/spec_rack_evil.rb
+++ b/test/spec_rack_evil.rb
@@ -12,8 +12,8 @@ describe "Rack::Evil" do
   specify "should enable the app to return the response from anywhere" do
     status, headers, body = Rack::Evil.new(app).call({})
 
-    status.must_equal 404
-    headers['Content-Type'].must_equal 'text/html'
-    body.must_equal 'Never know where it comes from'
+    _(status).must_equal 404
+    _(headers['Content-Type']).must_equal 'text/html'
+    _(body).must_equal 'Never know where it comes from'
   end
 end

--- a/test/spec_rack_expectation_cascade.rb
+++ b/test/spec_rack_expectation_cascade.rb
@@ -7,16 +7,16 @@ describe "Rack::ExpectationCascade" do
     app = Rack::ExpectationCascade.new
     env = {}
     response = app.call(env)
-    response[0].must_equal 404
-    env.must_equal({})
+    _(response[0]).must_equal 404
+    _(env).must_equal({})
   end
 
   specify "with no apps returns a 417 if expectation header was set" do
     app = Rack::ExpectationCascade.new
     env = {"Expect" => "100-continue"}
     response = app.call(env)
-    response[0].must_equal 417
-    env.must_equal({"Expect" => "100-continue"})
+    _(response[0]).must_equal 417
+    _(env).must_equal({"Expect" => "100-continue"})
   end
 
   specify "returns first successful response" do
@@ -25,8 +25,8 @@ describe "Rack::ExpectationCascade" do
       cascade << lambda { |env| [200, {"Content-Type" => "text/plain"}, ["OK"]] }
     end
     response = app.call({})
-    response[0].must_equal 200
-    response[2][0].must_equal "OK"
+    _(response[0]).must_equal 200
+    _(response[2][0]).must_equal "OK"
   end
 
   specify "expectation is set if it has not been already" do
@@ -34,8 +34,8 @@ describe "Rack::ExpectationCascade" do
       cascade << lambda { |env| [200, {"Content-Type" => "text/plain"}, ["Expect: #{env["Expect"]}"]] }
     end
     response = app.call({})
-    response[0].must_equal 200
-    response[2][0].must_equal "Expect: 100-continue"
+    _(response[0]).must_equal 200
+    _(response[2][0]).must_equal "Expect: 100-continue"
   end
 
   specify "returns a 404 if no apps where matched and no expectation header was set" do
@@ -43,8 +43,8 @@ describe "Rack::ExpectationCascade" do
       cascade << lambda { |env| [417, {"Content-Type" => "text/plain"}, []] }
     end
     response = app.call({})
-    response[0].must_equal 404
-    response[2][0].must_be_nil
+    _(response[0]).must_equal 404
+    _(response[2][0]).must_be_nil
   end
 
   specify "returns a 417 if no apps where matched and a expectation header was set" do
@@ -52,8 +52,8 @@ describe "Rack::ExpectationCascade" do
       cascade << lambda { |env| [417, {"Content-Type" => "text/plain"}, []] }
     end
     response = app.call({"Expect" => "100-continue"})
-    response[0].must_equal 417
-    response[2][0].must_be_nil
+    _(response[0]).must_equal 417
+    _(response[2][0]).must_be_nil
   end
 
   specify "nests expectation cascades" do
@@ -66,7 +66,7 @@ describe "Rack::ExpectationCascade" do
       end
     end
     response = app.call({})
-    response[0].must_equal 200
-    response[2][0].must_equal "OK"
+    _(response[0]).must_equal 200
+    _(response[2][0]).must_equal "OK"
   end
 end

--- a/test/spec_rack_host_meta.rb
+++ b/test/spec_rack_host_meta.rb
@@ -20,31 +20,31 @@ describe "Rack::HostMeta" do
   end
 
   specify "should respond to /host-meta" do
-    @response.status.must_equal 200
+    _(@response.status).must_equal 200
   end
 
   specify "should respond with the correct media type" do
-    @response['Content-Type'].must_equal 'application/host-meta'
+    _(@response['Content-Type']).must_equal 'application/host-meta'
   end
 
   specify "should include a Link entry for each Link item in the config block" do
-    @response.body.must_match(/Link:\s*<\/robots.txt>;.*\n/)
-    @response.body.must_match(/Link:\s*<\/w3c\/p3p.xml>;.*/)
+    _(@response.body).must_match(/Link:\s*<\/robots.txt>;.*\n/)
+    _(@response.body).must_match(/Link:\s*<\/w3c\/p3p.xml>;.*/)
   end
 
   specify "should include a Link-Pattern entry for each Link-Pattern item in the config" do
-    @response.body.must_match(/Link-Pattern:\s*<\{uri\};json_schema>;.*/)
+    _(@response.body).must_match(/Link-Pattern:\s*<\{uri\};json_schema>;.*/)
   end
 
   specify "should include a rel attribute for each Link or Link-Pattern entry where specified" do
-    @response.body.must_match(/rel="robots"/)
-    @response.body.must_match(/rel="privacy"/)
-    @response.body.must_match(/rel="describedby"/)
+    _(@response.body).must_match(/rel="robots"/)
+    _(@response.body).must_match(/rel="privacy"/)
+    _(@response.body).must_match(/rel="describedby"/)
   end
 
   specify "should include a type attribute for each Link or Link-Pattern entry where specified" do
-    @response.body.must_match(/Link:\s*<\/w3c\/p3p.xml>;.*type.*application\/p3p.xml/)
-    @response.body.must_match(/Link-Pattern:\s*<\{uri\};json_schema>;.*type.*application\/x-schema\+json/)
+    _(@response.body).must_match(/Link:\s*<\/w3c\/p3p.xml>;.*type.*application\/p3p.xml/)
+    _(@response.body).must_match(/Link-Pattern:\s*<\{uri\};json_schema>;.*type.*application\/x-schema\+json/)
   end
 
 end

--- a/test/spec_rack_jsonp.rb
+++ b/test/spec_rack_jsonp.rb
@@ -11,7 +11,7 @@ describe "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       body = Rack::JSONP.new(app).call(request).last
-      body.must_equal ["/**/#{callback}(#{test_body})"]
+      _(body).must_equal ["/**/#{callback}(#{test_body})"]
     end
 
     specify "should not wrap the response body in a callback if body is not JSON" do
@@ -20,7 +20,7 @@ describe "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       body = Rack::JSONP.new(app).call(request).last
-      body.must_equal ['{"bar":"foo"}']
+      _(body).must_equal ['{"bar":"foo"}']
     end
 
     specify "should update content length if it was set" do
@@ -31,7 +31,7 @@ describe "Rack::JSONP" do
 
       headers = Rack::JSONP.new(app).call(request)[1]
       expected_length = "/**/".length + test_body.length + callback.length + "()".length
-      headers['Content-Length'].must_equal(expected_length.to_s)
+      _(headers['Content-Length']).must_equal(expected_length.to_s)
     end
 
     specify "should not touch content length if not set" do
@@ -40,7 +40,7 @@ describe "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       headers = Rack::JSONP.new(app).call(request)[1]
-      headers['Content-Length'].must_be_nil
+      _(headers['Content-Length']).must_be_nil
     end
 
     specify "should modify the content type to application/javascript" do
@@ -49,7 +49,7 @@ describe "Rack::JSONP" do
       app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       headers = Rack::JSONP.new(app).call(request)[1]
-      headers['Content-Type'].must_equal('application/javascript')
+      _(headers['Content-Type']).must_equal('application/javascript')
     end
 
     specify "should not allow literal U+2028 or U+2029" do
@@ -63,9 +63,9 @@ describe "Rack::JSONP" do
       request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
       body = Rack::JSONP.new(app).call(request).last
       unless "\u2028" == 'u2028'
-        body.join.wont_match(/\u2028|\u2029/)
+        _(body.join).wont_match(/\u2028|\u2029/)
       else
-        body.join.wont_match(/\342\200\250|\342\200\251/)
+        _(body.join).wont_match(/\342\200\250|\342\200\251/)
       end
     end
 
@@ -76,7 +76,7 @@ describe "Rack::JSONP" do
         app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
         request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
         body = Rack::JSONP.new(app).call(request).last
-        body.must_equal ['{"bar":"foo"}']
+        _(body).must_equal ['{"bar":"foo"}']
       end
 
       specify "without assignment" do
@@ -84,7 +84,7 @@ describe "Rack::JSONP" do
         app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
         request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback")
         body = Rack::JSONP.new(app).call(request).last
-        body.must_equal ['{"bar":"foo"}']
+        _(body).must_equal ['{"bar":"foo"}']
       end
     end
 
@@ -97,7 +97,7 @@ describe "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           body = Rack::JSONP.new(app).call(request).last
-          body.must_equal ['Bad Request']
+          _(body).must_equal ['Bad Request']
         end
 
         specify 'should return set the response code to 400' do
@@ -107,7 +107,7 @@ describe "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           response_code = Rack::JSONP.new(app).call(request).first
-          response_code.must_equal 400
+          _(response_code).must_equal 400
         end
       end
 
@@ -119,7 +119,7 @@ describe "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           body = Rack::JSONP.new(app).call(request).last
-          body.must_equal ['Good Request']
+          _(body).must_equal ['Good Request']
         end
 
         specify 'should not change the response code from 200' do
@@ -129,7 +129,7 @@ describe "Rack::JSONP" do
           app = lambda { |env| [200, {'Content-Type' => content_type}, [test_body]] }
           request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
           response_code = Rack::JSONP.new(app).call(request).first
-          response_code.must_equal 200
+          _(response_code).must_equal 200
         end
       end
     end
@@ -142,10 +142,10 @@ describe "Rack::JSONP" do
       end
 
       def assert_bad_request(response)
-        response.wont_be_nil
+        _(response).wont_be_nil
         status, headers, body = response
-        status.must_equal 400
-        body.must_equal ["Bad Request"]
+        _(status).must_equal 400
+        _(body).must_equal ["Bad Request"]
       end
 
       specify "should return bad request for callback with invalid characters" do
@@ -162,8 +162,8 @@ describe "Rack::JSONP" do
 
       specify "should not return a bad request for callbacks with dots in the callback" do
         status, headers, body = request(callback = "foo.bar.baz", test_body = '{"foo":"bar"}')
-        status.must_equal 200
-        body.must_equal ["/**/#{callback}(#{test_body})"]
+        _(status).must_equal 200
+        _(body).must_equal ["/**/#{callback}(#{test_body})"]
       end
     end
 
@@ -174,7 +174,7 @@ describe "Rack::JSONP" do
     app = lambda { |env| [200, {'Content-Type' => 'application/json'}, test_body] }
     request = Rack::MockRequest.env_for("/", :params => "foo=bar")
     body = Rack::JSONP.new(app).call(request).last
-    body.must_equal test_body
+    _(body).must_equal test_body
   end
 
   specify "should not change anything if it's not a json response" do
@@ -182,7 +182,7 @@ describe "Rack::JSONP" do
     app = lambda { |env| [404, {'Content-Type' => 'text/html'}, [test_body]] }
     request = Rack::MockRequest.env_for("/", :params => "callback=foo", 'HTTP_ACCEPT' => 'application/json')
     body = Rack::JSONP.new(app).call(request).last
-    body.must_equal [test_body]
+    _(body).must_equal [test_body]
   end
 
   specify "should not change anything if there is no Content-Type header" do
@@ -190,7 +190,7 @@ describe "Rack::JSONP" do
     app = lambda { |env| [404, {}, [test_body]] }
     request = Rack::MockRequest.env_for("/", :params => "callback=foo", 'HTTP_ACCEPT' => 'application/json')
     body = Rack::JSONP.new(app).call(request).last
-    body.must_equal [test_body]
+    _(body).must_equal [test_body]
   end
 
   specify "should not change anything if the request doesn't have a body" do
@@ -198,8 +198,8 @@ describe "Rack::JSONP" do
     app2 = lambda { |env| [204, {}, []] }
     app3 = lambda { |env| [304, {}, []] }
     request = Rack::MockRequest.env_for("/", :params => "callback=foo", 'HTTP_ACCEPT' => 'application/json')
-    Rack::JSONP.new(app1).call(request).must_equal app1.call({})
-    Rack::JSONP.new(app2).call(request).must_equal app2.call({})
-    Rack::JSONP.new(app3).call(request).must_equal app3.call({})
+    _(Rack::JSONP.new(app1).call(request)).must_equal app1.call({})
+    _(Rack::JSONP.new(app2).call(request)).must_equal app2.call({})
+    _(Rack::JSONP.new(app3).call(request)).must_equal app3.call({})
   end
 end

--- a/test/spec_rack_lighttpd_script_name_fix.rb
+++ b/test/spec_rack_lighttpd_script_name_fix.rb
@@ -10,7 +10,7 @@ describe "Rack::LighttpdScriptNameFix" do
     }
     app = lambda { |_| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     response = Rack::LighttpdScriptNameFix.new(app).call(env)
-    env['SCRIPT_NAME'].empty?.must_equal(true)
-    env['PATH_INFO'].must_equal '/hello/foo/bar/baz'
+    _(env['SCRIPT_NAME'].empty?).must_equal(true)
+    _(env['PATH_INFO']).must_equal '/hello/foo/bar/baz'
   end
 end

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -34,52 +34,52 @@ begin
 
     specify 'should use I18n.default_locale if no languages are requested' do
       I18n.default_locale = :zh
-      response_with_languages(nil).body.must_equal('zh')
+      _(response_with_languages(nil).body).must_equal('zh')
     end
 
     specify 'should treat an empty qvalue as 1.0' do
-      response_with_languages('en,es;q=0.95').body.must_equal('en')
+      _(response_with_languages('en,es;q=0.95').body).must_equal('en')
     end
 
     specify 'should set the Content-Language response header' do
       headers = response_with_languages('de;q=0.7,dk;q=0.9').headers
-      headers['Content-Language'].must_equal('dk')
+      _(headers['Content-Language']).must_equal('dk')
     end
 
     specify 'should pick the language with the highest qvalue' do
-      response_with_languages('en;q=0.9,es;q=0.95').body.must_equal('es')
+      _(response_with_languages('en;q=0.9,es;q=0.95').body).must_equal('es')
     end
 
     specify 'should retain full language codes' do
-      response_with_languages('en-gb,en-us;q=0.95;en').body.must_equal('en-gb')
+      _(response_with_languages('en-gb,en-us;q=0.95;en').body).must_equal('en-gb')
     end
 
     specify 'should treat a * as "all other languages"' do
-      response_with_languages('*,en;q=0.5').body.must_equal(I18n.default_locale.to_s)
+      _(response_with_languages('*,en;q=0.5').body).must_equal(I18n.default_locale.to_s)
     end
 
     specify 'should reset the I18n locale after the response' do
       I18n.locale = :es
       response_with_languages('en,de;q=0.8')
-      I18n.locale.must_equal(:es)
+      _(I18n.locale).must_equal(:es)
     end
 
     specify 'should pick the available language' do
       enforce_available_locales(true) do
-        response_with_languages('ch,en;q=0.9,es;q=0.95').body.must_equal('es')
+        _(response_with_languages('ch,en;q=0.9,es;q=0.95').body).must_equal('es')
       end
     end
 
     specify 'should use default_locale if there is no matching language while enforcing available_locales' do
       I18n.default_locale = :zh
       enforce_available_locales(true) do
-        response_with_languages('ja').body.must_equal('zh')
+        _(response_with_languages('ja').body).must_equal('zh')
       end
     end
 
     specify 'when not enforce should pick the language with the highest qvalue' do
       enforce_available_locales(false) do
-        response_with_languages('ch,en;q=0.9').body.must_equal('ch')
+        _(response_with_languages('ch,en;q=0.9').body).must_equal('ch')
       end
     end
   end

--- a/test/spec_rack_mailexceptions.rb
+++ b/test/spec_rack_mailexceptions.rb
@@ -43,7 +43,7 @@ begin
           mail.subject '[ERROR] %s'
           mail.smtp @smtp_settings
         end
-      called.must_equal(true)
+      _(called).must_equal(true)
     end
 
     specify 'generates a Mail object with configured settings' do
@@ -56,12 +56,12 @@ begin
         end
 
       mail = mailer.send(:generate_mail, test_exception, @env)
-      mail.to.must_equal ['foo@example.org']
-      mail.from.must_equal ['bar@example.org']
-      mail.subject.must_equal '[ERROR] Suffering Succotash!'
-      mail.body.wont_equal(nil)
-      mail.body.to_s.must_match(/FOO:\s+"BAR"/)
-      mail.body.to_s.must_match(/^\s*THE BODY\s*$/)
+      _(mail.to).must_equal ['foo@example.org']
+      _(mail.from).must_equal ['bar@example.org']
+      _(mail.subject).must_equal '[ERROR] Suffering Succotash!'
+      _(mail.body).wont_equal(nil)
+      _(mail.body.to_s).must_match(/FOO:\s+"BAR"/)
+      _(mail.body.to_s).must_match(/^\s*THE BODY\s*$/)
     end
 
     specify 'filters HTTP_EXCEPTION body' do
@@ -77,7 +77,7 @@ begin
       env['HTTP_AUTHORIZATION'] = 'Basic xyzzy12345'
 
       mail = mailer.send(:generate_mail, test_exception, env)
-      mail.body.to_s.must_match /HTTP_AUTHORIZATION:\s+"Basic \*filtered\*"/
+      _(mail.body.to_s).must_match /HTTP_AUTHORIZATION:\s+"Basic \*filtered\*"/
     end
 
     specify 'catches exceptions raised from app, sends mail, and re-raises' do
@@ -89,9 +89,9 @@ begin
           mail.smtp @smtp_settings
         end
       mailer.enable_test_mode
-      lambda { mailer.call(@env) }.must_raise(TestError)
-      @env['mail.sent'].must_equal(true)
-      Mail::TestMailer.deliveries.length.must_equal(1)
+      _(lambda { mailer.call(@env) }).must_raise(TestError)
+      _(@env['mail.sent']).must_equal(true)
+      _(Mail::TestMailer.deliveries.length).must_equal(1)
     end
   end
 rescue LoadError => boom

--- a/test/spec_rack_nested_params.rb
+++ b/test/spec_rack_nested_params.rb
@@ -22,25 +22,25 @@ describe Rack::NestedParams do
 
   specify "should handle requests with POST body Content-Type of application/x-www-form-urlencoded" do
     req = middleware.call(form_post({'foo[bar][baz]' => 'nested'})).last
-    req.POST.must_equal({"foo" => { "bar" => { "baz" => "nested" }}})
+    _(req.POST).must_equal({"foo" => { "bar" => { "baz" => "nested" }}})
   end
 
   specify "should not parse requests with other Content-Type" do
     req = middleware.call(form_post({'foo[bar][baz]' => 'nested'}, 'text/plain')).last
-    req.POST.must_equal({})
+    _(req.POST).must_equal({})
   end
 
   specify "should work even after another middleware already parsed the request" do
     app = Rack::MethodOverride.new(middleware)
     req = app.call(form_post({'_method' => 'put', 'foo[bar]' => 'nested'})).last
-    req.POST.must_equal({'_method' => 'put', "foo" => { "bar" => "nested" }})
-    req.put?.must_equal true
+    _(req.POST).must_equal({'_method' => 'put', "foo" => { "bar" => "nested" }})
+    _(req.put?).must_equal true
   end
 
   specify "should make last boolean have precedence even after request already parsed" do
     app = Rack::MethodOverride.new(middleware)
     req = app.call(form_post("foo=1&foo=0")).last
-    req.POST.must_equal({"foo" => "0"})
+    _(req.POST).must_equal({"foo" => "0"})
   end
 
 end

--- a/test/spec_rack_not_found.rb
+++ b/test/spec_rack_not_found.rb
@@ -11,10 +11,10 @@ describe "Rack::NotFound" do
       run Rack::NotFound.new('test/404.html')
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal('Custom 404 page content')
-    response.headers['Content-Length'].must_equal('23')
-    response.headers['Content-Type'].must_equal('text/html')
-    response.status.must_equal(404)
+    _(response.body).must_equal('Custom 404 page content')
+    _(response.headers['Content-Length']).must_equal('23')
+    _(response.headers['Content-Type']).must_equal('text/html')
+    _(response.status).must_equal(404)
   end
 
   specify "should render the default response body if no path specified" do
@@ -23,10 +23,10 @@ describe "Rack::NotFound" do
       run Rack::NotFound.new
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal("Not found\n")
-    response.headers['Content-Length'].must_equal('10')
-    response.headers['Content-Type'].must_equal('text/html')
-    response.status.must_equal(404)
+    _(response.body).must_equal("Not found\n")
+    _(response.headers['Content-Length']).must_equal('10')
+    _(response.headers['Content-Type']).must_equal('text/html')
+    _(response.status).must_equal(404)
   end
 
   specify "should accept an alternate content type" do
@@ -35,10 +35,10 @@ describe "Rack::NotFound" do
       run Rack::NotFound.new(nil, 'text/plain')
     end
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal("Not found\n")
-    response.headers['Content-Length'].must_equal('10')
-    response.headers['Content-Type'].must_equal('text/plain')
-    response.status.must_equal(404)
+    _(response.body).must_equal("Not found\n")
+    _(response.headers['Content-Length']).must_equal('10')
+    _(response.headers['Content-Type']).must_equal('text/plain')
+    _(response.status).must_equal(404)
   end
 
   specify "should return correct size" do
@@ -52,7 +52,7 @@ describe "Rack::NotFound" do
         run Rack::NotFound.new(f.path)
       end
       response = Rack::MockRequest.new(app).get('/')
-      response.headers['Content-Length'].must_equal('46')
+      _(response.headers['Content-Length']).must_equal('46')
     end
   end
 end

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -8,45 +8,45 @@ begin
 
     specify "should parse 'application/json' requests" do
       params = params_for_request '{"key":"value"}', "application/json"
-      params['key'].must_equal "value"
+      _(params['key']).must_equal "value"
     end
 
     specify "should parse 'application/json; charset=utf-8' requests" do
       params = params_for_request '{"key":"value"}', "application/json; charset=utf-8"
-      params['key'].must_equal "value"
+      _(params['key']).must_equal "value"
     end
 
     specify "should parse 'application/json' requests with empty body" do
       params = params_for_request "", "application/json"
-      params.must_equal({})
+      _(params).must_equal({})
     end
 
     specify "shouldn't affect form-urlencoded requests" do
       params = params_for_request("key=value", "application/x-www-form-urlencoded")
-      params['key'].must_equal "value"
+      _(params['key']).must_equal "value"
     end
 
     specify "should not create additions" do
       before = Symbol.all_symbols
       params_for_request %{{"json_class":"this_should_not_be_added"}}, "application/json" rescue nil
       result = Symbol.all_symbols - before
-      result.must_be_empty
+      _(result).must_be_empty
     end
 
     specify "should apply given block to body" do
       params = params_for_request '{"key":"value"}', "application/json" do |body|
         { 'payload' => JSON.parse(body) }
       end
-      params['payload'].wont_be_nil
-      params['payload']['key'].must_equal "value"
+      _(params['payload']).wont_be_nil
+      _(params['payload']['key']).must_equal "value"
     end
 
     describe "contradiction between body and type" do
       def assert_failed_to_parse_as_json(response)
-        response.wont_be_nil
+        _(response).wont_be_nil
         status, headers, body = response
-        status.must_equal 400
-        body.must_equal ["failed to parse body as JSON"]
+        _(status).must_equal 400
+        _(body).must_equal ["failed to parse body as JSON"]
       end
 
       specify "should return bad request with invalid JSON" do

--- a/test/spec_rack_proctitle.rb
+++ b/test/spec_rack_proctitle.rb
@@ -12,13 +12,13 @@ describe "Rack::ProcTitle" do
 
   specify "should set the process title when created" do
     Rack::ProcTitle.new(simple_app)
-    $0.must_equal "#{progname} [#{appname}] init ..."
+    _($0).must_equal "#{progname} [#{appname}] init ..."
   end
 
   specify "should set the process title on each request" do
     app = Rack::ProcTitle.new(simple_app)
     req = Rack::MockRequest.new(app)
     10.times { req.get('/hello') }
-    $0.must_equal "#{progname} [#{appname}/80] (10) GET /hello"
+    _($0).must_equal "#{progname} [#{appname}/80] (10) GET /hello"
   end
 end

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -10,31 +10,31 @@ begin
 
     specify 'printer defaults to RubyProf::CallStackPrinter' do
       profiler = Rack::Profiler.new(nil)
-      profiler.instance_variable_get('@printer').must_equal RubyProf::CallStackPrinter
-      profiler.instance_variable_get('@times').must_equal 1
+      _(profiler.instance_variable_get('@printer')).must_equal RubyProf::CallStackPrinter
+      _(profiler.instance_variable_get('@times')).must_equal 1
     end
 
     specify 'called multiple times via query params' do
       req = Rack::MockRequest.env_for("/", :params => "profile=process_time&profiler_runs=4")
       body = Rack::Profiler.new(app).call(req)[2].string
-      body.must_match(/Time#initialize \[4 calls, 4 total\]/)
+      _(body).must_match(/Time#initialize \[4 calls, 4 total\]/)
     end
 
     specify 'CallStackPrinter has Content-Type test/html' do
       headers = Rack::Profiler.new(app, :printer => :call_stack).call(request)[1]
-      headers.must_equal "Content-Type"=>"text/html"
+      _(headers).must_equal "Content-Type"=>"text/html"
     end
 
     specify 'FlatPrinter and GraphPrinter has Content-Type text/plain' do
       %w(flat graph).each do |printer|
         headers = Rack::Profiler.new(app, :printer => printer.to_sym).call(request)[1]
-        headers.must_equal "Content-Type"=>"text/plain"
+        _(headers).must_equal "Content-Type"=>"text/plain"
       end
     end
 
     specify 'GraphHtmlPrinter has Content-Type text/html' do
       headers = Rack::Profiler.new(app, :printer => :graph_html).call(request)[1]
-      headers.must_equal "Content-Type"=>"text/html"
+      _(headers).must_equal "Content-Type"=>"text/html"
     end
   end
 

--- a/test/spec_rack_relative_redirect.rb
+++ b/test/spec_rack_relative_redirect.rb
@@ -20,8 +20,8 @@ describe Rack::RelativeRedirect do
   specify "should rewrite Location on all the redirect codes" do
     [301, 302, 303, 307, 308].each do |status|
       request(:status => status) do |r|
-        r.status.must_equal(status)
-        r.headers['Location'].must_equal('http://example.org/redirect/to/blah')
+        _(r.status).must_equal(status)
+        _(r.headers['Location']).must_equal('http://example.org/redirect/to/blah')
       end
     end
   end
@@ -29,42 +29,42 @@ describe Rack::RelativeRedirect do
   specify "should not rewrite Location on other status codes" do
     [200, 201, 300, 304, 305, 306, 404, 500].each do |status|
       request(:status => status) do |r|
-        r.status.must_equal(status)
-        r.headers['Location'].must_equal('/redirect/to/blah')
+        _(r.status).must_equal(status)
+        _(r.headers['Location']).must_equal('/redirect/to/blah')
       end
     end
   end
 
   specify "should make the location url an absolute url if currently a relative url" do
     request do |r|
-      r.status.must_equal(301)
-      r.headers['Location'].must_equal('http://example.org/redirect/to/blah')
+      _(r.status).must_equal(301)
+      _(r.headers['Location']).must_equal('http://example.org/redirect/to/blah')
     end
     request(:status=>302, :location=>'/redirect') do |r|
-      r.status.must_equal(302)
-      r.headers['Location'].must_equal('http://example.org/redirect')
+      _(r.status).must_equal(302)
+      _(r.headers['Location']).must_equal('http://example.org/redirect')
     end
   end
 
   specify "should use the request path if the relative url is given and doesn't start with a slash" do
     request(:status=>303, :location=>'redirect/to/blah') do |r|
-      r.status.must_equal(303)
-      r.headers['Location'].must_equal('http://example.org/path/to/redirect/to/blah')
+      _(r.status).must_equal(303)
+      _(r.headers['Location']).must_equal('http://example.org/path/to/redirect/to/blah')
     end
     request(:status=>303, :location=>'redirect') do |r|
-      r.status.must_equal(303)
-      r.headers['Location'].must_equal('http://example.org/path/to/redirect')
+      _(r.status).must_equal(303)
+      _(r.headers['Location']).must_equal('http://example.org/path/to/redirect')
     end
   end
 
   specify "should use a given block to make the url absolute" do
     request(:block=>proc{|env, res| "https://example.org"}) do |r|
-      r.status.must_equal(301)
-      r.headers['Location'].must_equal('https://example.org/redirect/to/blah')
+      _(r.status).must_equal(301)
+      _(r.headers['Location']).must_equal('https://example.org/redirect/to/blah')
     end
     request(:status=>303, :location=>'/redirect', :block=>proc{|env, res| "https://e.org:9999/blah"}) do |r|
-      r.status.must_equal(303)
-      r.headers['Location'].must_equal('https://e.org:9999/blah/redirect')
+      _(r.status).must_equal(303)
+      _(r.headers['Location']).must_equal('https://e.org:9999/blah/redirect')
     end
   end
 
@@ -72,25 +72,25 @@ describe Rack::RelativeRedirect do
     status = 200
     @def_app = lambda { |env| [status, {'Content-Type' => "text/html"}, [""]]}
     request do |r|
-      r.status.must_equal(200)
-      r.headers.wont_include('Location')
+      _(r.status).must_equal(200)
+      _(r.headers).wont_include('Location')
     end
     status = 404
     @def_app = lambda { |env| [status, {'Content-Type' => "text/html", 'Location' => 'redirect'}, [""]]}
     request do |r|
-      r.status.must_equal(404)
-      r.headers['Location'].must_equal('redirect')
+      _(r.status).must_equal(404)
+      _(r.headers['Location']).must_equal('redirect')
     end
   end
 
   specify "should not modify the location url if it is already an absolute url" do
     request(:location=>'https://example.org/') do |r|
-      r.status.must_equal(301)
-      r.headers['Location'].must_equal('https://example.org/')
+      _(r.status).must_equal(301)
+      _(r.headers['Location']).must_equal('https://example.org/')
     end
     request(:status=>302, :location=>'https://e.org:9999/redirect') do |r|
-      r.status.must_equal(302)
-      r.headers['Location'].must_equal('https://e.org:9999/redirect')
+      _(r.status).must_equal(302)
+      _(r.headers['Location']).must_equal('https://e.org:9999/redirect')
     end
   end
 end

--- a/test/spec_rack_response_cache.rb
+++ b/test/spec_rack_response_cache.rb
@@ -21,123 +21,123 @@ describe Rack::ResponseCache do
 
   specify "should cache results to disk if cache is a string" do
     request(:cache=>@def_disk_cache)
-    ::File.read(::File.join(@def_disk_cache, 'path', 'to', 'blah.html')).must_equal @def_value.first
+    _(::File.read(::File.join(@def_disk_cache, 'path', 'to', 'blah.html'))).must_equal @def_value.first
     request(:path=>'/path/3', :cache=>@def_disk_cache)
-    ::File.read(::File.join(@def_disk_cache, 'path', '3.html')).must_equal @def_value.first
+    _(::File.read(::File.join(@def_disk_cache, 'path', '3.html'))).must_equal @def_value.first
   end
 
   specify "should cache results to given cache if cache is not a string" do
     request
-    @cache.must_equal('/path/to/blah.html'=>@def_value)
+    _(@cache).must_equal('/path/to/blah.html'=>@def_value)
     request(:path=>'/path/3')
-    @cache.must_equal('/path/to/blah.html'=>@def_value, '/path/3.html'=>@def_value)
+    _(@cache).must_equal('/path/to/blah.html'=>@def_value, '/path/3.html'=>@def_value)
   end
 
   specify "should run a case-insenstive lookup of the Content-Type header" do
     body = ['ok']
     request { |env| [200, {'content-type' => 'text/html'}, body]}
-    @cache.must_equal('/path/to/blah.html'=> body)
+    _(@cache).must_equal('/path/to/blah.html'=> body)
     request { |env| [200, {'ConTENT-TyPe' => 'text/html'}, body]}
-    @cache.must_equal('/path/to/blah.html'=> body)
+    _(@cache).must_equal('/path/to/blah.html'=> body)
   end
 
   specify "should not CACHE RESults if request method is not GET" do
     request(:meth=>:post)
-    @cache.must_equal({})
+    _(@cache).must_equal({})
     request(:meth=>:put)
-    @cache.must_equal({})
+    _(@cache).must_equal({})
     request(:meth=>:delete)
-    @cache.must_equal({})
+    _(@cache).must_equal({})
   end
 
   specify "should not cache results if there is a query string" do
     request(:path=>'/path/to/blah?id=1')
-    @cache.must_equal({})
+    _(@cache).must_equal({})
     request(:path=>'/path/to/?id=1')
-    @cache.must_equal({})
+    _(@cache).must_equal({})
     request(:path=>'/?id=1')
-    @cache.must_equal({})
+    _(@cache).must_equal({})
   end
 
   specify "should cache results if there is an empty query string" do
     request(:path=>'/?')
-    @cache.must_equal('/index.html'=>@def_value)
+    _(@cache).must_equal('/index.html'=>@def_value)
   end
 
   specify "should not cache results if the request is not successful (status 200)" do
     request{|env| [404, {'Content-Type' => 'text/html'}, ['']]}
-    @cache.must_equal({})
+    _(@cache).must_equal({})
     request{|env| [500, {'Content-Type' => 'text/html'}, ['']]}
-    @cache.must_equal({})
+    _(@cache).must_equal({})
     request{|env| [302, {'Content-Type' => 'text/html'}, ['']]}
-    @cache.must_equal({})
+    _(@cache).must_equal({})
   end
 
   specify "should not cache results if the block returns nil or false" do
     request(:rc_block=>proc{false})
-    @cache.must_equal({})
+    _(@cache).must_equal({})
     request(:rc_block=>proc{nil})
-    @cache.must_equal({})
+    _(@cache).must_equal({})
   end
 
   specify "should cache results to path returned by block" do
     request(:rc_block=>proc{"1"})
-    @cache.must_equal("1"=>@def_value)
+    _(@cache).must_equal("1"=>@def_value)
     request(:rc_block=>proc{"2"})
-    @cache.must_equal("1"=>@def_value, "2"=>@def_value)
+    _(@cache).must_equal("1"=>@def_value, "2"=>@def_value)
   end
 
   specify "should pass the environment and response to the block" do
     e, r = nil, nil
     request(:rc_block=>proc{|env,res| e, r = env, res; nil})
-    e['PATH_INFO'].must_equal @def_path
-    e['REQUEST_METHOD'].must_equal 'GET'
-    e['QUERY_STRING'].must_equal ''
-    r.must_equal([200, {"Content-Type"=>"text/html"}, ["rack-response-cache"]])
+    _(e['PATH_INFO']).must_equal @def_path
+    _(e['REQUEST_METHOD']).must_equal 'GET'
+    _(e['QUERY_STRING']).must_equal ''
+    _(r).must_equal([200, {"Content-Type"=>"text/html"}, ["rack-response-cache"]])
   end
 
   specify "should unescape the path by default" do
     request(:path=>'/path%20with%20spaces')
-    @cache.must_equal('/path with spaces.html'=>@def_value)
+    _(@cache).must_equal('/path with spaces.html'=>@def_value)
     request(:path=>'/path%3chref%3e')
-    @cache.must_equal('/path with spaces.html'=>@def_value, '/path<href>.html'=>@def_value)
+    _(@cache).must_equal('/path with spaces.html'=>@def_value, '/path<href>.html'=>@def_value)
   end
 
   specify "should cache html, css, and xml responses by default" do
     request(:path=>'/a')
-    @cache.must_equal('/a.html'=>@def_value)
+    _(@cache).must_equal('/a.html'=>@def_value)
     request(:path=>'/b', :headers=>{'CT'=>'text/xml'})
-    @cache.must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value)
+    _(@cache).must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value)
     request(:path=>'/c', :headers=>{'CT'=>'text/css'})
-    @cache.must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
+    _(@cache).must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
   end
 
   specify "should cache responses by default with the extension added if not already present" do
     request(:path=>'/a.html')
-    @cache.must_equal('/a.html'=>@def_value)
+    _(@cache).must_equal('/a.html'=>@def_value)
     request(:path=>'/b.xml', :headers=>{'CT'=>'text/xml'})
-    @cache.must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value)
+    _(@cache).must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value)
     request(:path=>'/c.css', :headers=>{'CT'=>'text/css'})
-    @cache.must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
+    _(@cache).must_equal('/a.html'=>@def_value, '/b.xml'=>@def_value, '/c.css'=>@def_value)
   end
 
   specify "should not delete existing extensions" do
     request(:path=>'/d.css', :headers=>{'CT'=>'text/html'})
-    @cache.must_equal('/d.css.html'=>@def_value)
+    _(@cache).must_equal('/d.css.html'=>@def_value)
   end
 
   specify "should cache html responses with empty basename to index.html by default" do
     request(:path=>'/')
-    @cache.must_equal('/index.html'=>@def_value)
+    _(@cache).must_equal('/index.html'=>@def_value)
     request(:path=>'/blah/')
-    @cache.must_equal('/index.html'=>@def_value, '/blah/index.html'=>@def_value)
+    _(@cache).must_equal('/index.html'=>@def_value, '/blah/index.html'=>@def_value)
     request(:path=>'/blah/2/')
-    @cache.must_equal('/index.html'=>@def_value, '/blah/index.html'=>@def_value, '/blah/2/index.html'=>@def_value)
+    _(@cache).must_equal('/index.html'=>@def_value, '/blah/index.html'=>@def_value, '/blah/2/index.html'=>@def_value)
   end
 
   specify "should raise an error if a cache argument is not provided" do
     app = Rack::Builder.new{use Rack::ResponseCache; run lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST]}}
-    proc{Rack::MockRequest.new(app).get('/')}.must_raise(ArgumentError)
+    _(proc{Rack::MockRequest.new(app).get('/')}).must_raise(ArgumentError)
   end
 
 end

--- a/test/spec_rack_response_headers.rb
+++ b/test/spec_rack_response_headers.rb
@@ -9,7 +9,7 @@ describe "Rack::ResponseHeaders" do
     app = Proc.new {[200, orig_headers, []]}
     middleware = Rack::ResponseHeaders.new(app) do |headers|
       assert_instance_of Rack::Utils::HeaderHash, headers
-      orig_headers.must_equal headers
+      _(orig_headers).must_equal headers
     end
     middleware.call({})
   end
@@ -20,7 +20,7 @@ describe "Rack::ResponseHeaders" do
       headers['X-Bar'] = 'bar'
     end
     r = middleware.call({})
-    r[1].must_equal('X-Foo' => 'foo', 'X-Bar' => 'bar')
+    _(r[1]).must_equal('X-Foo' => 'foo', 'X-Bar' => 'bar')
   end
 
   specify "allows deleting headers" do
@@ -29,7 +29,7 @@ describe "Rack::ResponseHeaders" do
       headers.delete('X-Bar')
     end
     r = middleware.call({})
-    r[1].must_equal('X-Foo' => 'foo')
+    _(r[1]).must_equal('X-Foo' => 'foo')
   end
 
 end

--- a/test/spec_rack_runtime.rb
+++ b/test/spec_rack_runtime.rb
@@ -6,19 +6,19 @@ describe "Rack::Runtime" do
   specify "sets X-Runtime is none is set" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, "Hello, World!"] }
     response = Rack::Runtime.new(app).call({})
-    response[1]['X-Runtime'].must_match /[\d\.]+/
+    _(response[1]['X-Runtime']).must_match /[\d\.]+/
   end
 
   specify "does not set the X-Runtime if it is already set" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain', "X-Runtime" => "foobar"}, "Hello, World!"] }
     response = Rack::Runtime.new(app).call({})
-    response[1]['X-Runtime'].must_equal "foobar"
+    _(response[1]['X-Runtime']).must_equal "foobar"
   end
 
   specify "should allow a suffix to be set" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, "Hello, World!"] }
     response = Rack::Runtime.new(app, "Test").call({})
-    response[1]['X-Runtime-Test'].must_match /[\d\.]+/
+    _(response[1]['X-Runtime-Test']).must_match /[\d\.]+/
   end
 
   specify "should allow multiple timers to be set" do
@@ -27,9 +27,9 @@ describe "Rack::Runtime" do
     runtime2 = Rack::Runtime.new(runtime1, "All")
     response = runtime2.call({})
 
-    response[1]['X-Runtime-App'].must_match /[\d\.]+/
-    response[1]['X-Runtime-All'].must_match /[\d\.]+/
+    _(response[1]['X-Runtime-App']).must_match /[\d\.]+/
+    _(response[1]['X-Runtime-All']).must_match /[\d\.]+/
 
-    (Float(response[1]['X-Runtime-All']) > Float(response[1]['X-Runtime-App'])).must_equal(true)
+    _(Float(response[1]['X-Runtime-All']) > Float(response[1]['X-Runtime-App'])).must_equal(true)
   end
 end

--- a/test/spec_rack_simple_endpoint.rb
+++ b/test/spec_rack_simple_endpoint.rb
@@ -10,50 +10,50 @@ describe "Rack::SimpleEndpoint" do
   specify "calls downstream app when no match" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/baz'))
-    status.must_equal 200
-    body.body.must_equal ['Downstream app']
+    _(status).must_equal 200
+    _(body.body).must_equal ['Downstream app']
   end
 
   specify "calls downstream app when path matches but method does not" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => :get) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo', :method => 'post'))
-    status.must_equal 200
-    body.body.must_equal ['Downstream app']
+    _(status).must_equal 200
+    _(body.body).must_equal ['Downstream app']
   end
 
   specify "calls downstream app when path matches but block returns :pass" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { :pass }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
-    status.must_equal 200
-    body.body.must_equal ['Downstream app']
+    _(status).must_equal 200
+    _(body.body).must_equal ['Downstream app']
   end
 
   specify "returns endpoint response when path matches" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
-    status.must_equal 200
-    body.body.must_equal ['bar']
+    _(status).must_equal 200
+    _(body.body).must_equal ['bar']
   end
 
   specify "returns endpoint response when path and single method requirement match" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => :get) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
-    status.must_equal 200
-    body.body.must_equal ['bar']
+    _(status).must_equal 200
+    _(body.body).must_equal ['bar']
   end
 
   specify "returns endpoint response when path and one of multiple method requirements match" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => [:get, :post]) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo', :method => 'post'))
-    status.must_equal 200
-    body.body.must_equal ['bar']
+    _(status).must_equal 200
+    _(body.body).must_equal ['bar']
   end
 
   specify "returns endpoint response when path matches regex" do
     endpoint = Rack::SimpleEndpoint.new(@app, /foo/) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/bar/foo'))
-    status.must_equal 200
-    body.body.must_equal ['bar']
+    _(status).must_equal 200
+    _(body.body).must_equal ['bar']
   end
 
   specify "block yields Rack::Request and Rack::Response objects" do
@@ -82,14 +82,14 @@ describe "Rack::SimpleEndpoint" do
   specify "response honors headers set in block" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') {|req, res| res['X-Foo'] = 'bar'; 'baz' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
-    status.must_equal 200
-    headers['X-Foo'].must_equal 'bar'
-    body.body.must_equal ['baz']
+    _(status).must_equal 200
+    _(headers['X-Foo']).must_equal 'bar'
+    _(body.body).must_equal ['baz']
   end
   
   specify "sets Content-Length header" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') {|req, res| 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
-    headers['Content-Length'].must_equal '3'
+    _(headers['Content-Length']).must_equal '3'
   end
 end

--- a/test/spec_rack_simple_endpoint.rb
+++ b/test/spec_rack_simple_endpoint.rb
@@ -7,53 +7,58 @@ describe "Rack::SimpleEndpoint" do
     @app = Proc.new { Rack::Response.new {|r| r.write "Downstream app"}.finish }
   end
 
+  # We use the thick with body `body.to_enum.to_a` instead of checking a body
+  # directly only because the tests suite can be run against different versions
+  # of Rack. Some versions can return Rack::BodyProxy instead of simple
+  # array
+
   specify "calls downstream app when no match" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/baz'))
     _(status).must_equal 200
-    _(body.body).must_equal ['Downstream app']
+    _(body.to_enum.to_a).must_equal ['Downstream app']
   end
 
   specify "calls downstream app when path matches but method does not" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => :get) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo', :method => 'post'))
     _(status).must_equal 200
-    _(body.body).must_equal ['Downstream app']
+    _(body.to_enum.to_a).must_equal ['Downstream app']
   end
 
   specify "calls downstream app when path matches but block returns :pass" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { :pass }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
-    _(body.body).must_equal ['Downstream app']
+    _(body.to_enum.to_a).must_equal ['Downstream app']
   end
 
   specify "returns endpoint response when path matches" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
-    _(body.body).must_equal ['bar']
+    _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "returns endpoint response when path and single method requirement match" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => :get) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
-    _(body.body).must_equal ['bar']
+    _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "returns endpoint response when path and one of multiple method requirements match" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => [:get, :post]) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo', :method => 'post'))
     _(status).must_equal 200
-    _(body.body).must_equal ['bar']
+    _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "returns endpoint response when path matches regex" do
     endpoint = Rack::SimpleEndpoint.new(@app, /foo/) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/bar/foo'))
     _(status).must_equal 200
-    _(body.body).must_equal ['bar']
+    _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "block yields Rack::Request and Rack::Response objects" do
@@ -84,9 +89,9 @@ describe "Rack::SimpleEndpoint" do
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
     _(headers['X-Foo']).must_equal 'bar'
-    _(body.body).must_equal ['baz']
+    _(body.to_enum.to_a).must_equal ['baz']
   end
-  
+
   specify "sets Content-Length header" do
     endpoint = Rack::SimpleEndpoint.new(@app, '/foo') {|req, res| 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))

--- a/test/spec_rack_static_cache.rb
+++ b/test/spec_rack_static_cache.rb
@@ -26,24 +26,24 @@ describe "Rack::StaticCache" do
     end
 
     it "should serve the request successfully" do
-      get_request("/statics/test").ok?.must_equal(true)
+      _(get_request("/statics/test").ok?).must_equal(true)
     end
 
     it "should serve the correct file contents" do
-      get_request("/statics/test").body.must_match(/rubyrack/)
+      _(get_request("/statics/test").body).must_match(/rubyrack/)
     end
 
     it "should serve the correct file contents for a file with an extension" do
-      get_request("/statics/test.html").body.must_match(/extensions rule!/)
+      _(get_request("/statics/test.html").body).must_match(/extensions rule!/)
     end
 
     it "should set a long Cache-Control max-age" do
-      get_request("/statics/test").headers['Cache-Control'].must_equal 'max-age=31536000, public'
+      _(get_request("/statics/test").headers['Cache-Control']).must_equal 'max-age=31536000, public'
     end
 
     it "should set a long-distant Expires header" do
       next_year = Time.now().year + 1
-      get_request("/statics/test").headers['Expires'].must_match(
+      _(get_request("/statics/test").headers['Expires']).must_match(
         Regexp.new(
           "[A-Z][a-z]{2}[,][\s][0-9]{2}[\s][A-Z][a-z]{2}[\s]" <<
           "#{next_year}" <<
@@ -53,22 +53,22 @@ describe "Rack::StaticCache" do
     end
 
     it "should return 404s if url root is known but it can't find the file" do
-      get_request("/statics/non-existent").not_found?.must_equal(true)
+      _(get_request("/statics/non-existent").not_found?).must_equal(true)
     end
 
     it "should call down the chain if url root is not known" do
       res = get_request("/something/else")
-      res.ok?.must_equal(true)
-      res.body.must_equal "Hello World"
+      _(res.ok?).must_equal(true)
+      _(res.body).must_equal "Hello World"
     end
 
     it "should serve files if requested with version number" do
       res = get_request("/statics/test-0.0.1")
-      res.ok?.must_equal(true)
+      _(res.ok?).must_equal(true)
     end
 
     it "should serve the correct file contents for a file with an extension requested with a version" do
-      get_request("/statics/test-0.0.1.html").body.must_match(/extensions rule!/)
+      _(get_request("/statics/test-0.0.1.html").body).must_match(/extensions rule!/)
     end
   end
 
@@ -78,15 +78,15 @@ describe "Rack::StaticCache" do
     end
 
     it "should handle requests with the custom regex" do
-      get_request("/statics/test-deadbeef").ok?.must_equal(true)
+      _(get_request("/statics/test-deadbeef").ok?).must_equal(true)
     end
 
     it "should handle extensioned requests for the custom regex" do
-      get_request("/statics/test-deadbeef.html").body.must_match(/extensions rule!/)
+      _(get_request("/statics/test-deadbeef.html").body).must_match(/extensions rule!/)
     end
 
     it "should not handle requests for the default version regex" do
-      get_request("/statics/test-0.0.1").ok?.must_equal(false)
+      _(get_request("/statics/test-0.0.1").ok?).must_equal(false)
     end
   end
 
@@ -97,7 +97,7 @@ describe "Rack::StaticCache" do
 
     it "should change cache duration" do
       next_next_year = Time.now().year + 2
-      get_request("/statics/test").headers['Expires'].must_match(Regexp.new("#{next_next_year}"))
+      _(get_request("/statics/test").headers['Expires']).must_match(Regexp.new("#{next_next_year}"))
     end
   end
 
@@ -107,7 +107,7 @@ describe "Rack::StaticCache" do
     end
 
     it "should round max-age if duration is part of a year" do
-      get_request("/statics/test").headers['Cache-Control'].must_equal "max-age=606461, public"
+      _(get_request("/statics/test").headers['Cache-Control']).must_equal "max-age=606461, public"
     end
   end
 
@@ -117,7 +117,7 @@ describe "Rack::StaticCache" do
     end
 
     it "should return 404s if requested with version number" do
-      get_request("/statics/test-0.0.1").not_found?.must_equal(true)
+      _(get_request("/statics/test-0.0.1").not_found?).must_equal(true)
     end
   end
 
@@ -127,19 +127,19 @@ describe "Rack::StaticCache" do
     end
 
     it "should serve files OK" do
-      get_request("/statics/test").ok?.must_equal(true)
+      _(get_request("/statics/test").ok?).must_equal(true)
     end
 
     it "should serve the content" do
-      get_request("/statics/test").body.must_match(/rubyrack/)
+      _(get_request("/statics/test").body).must_match(/rubyrack/)
     end
 
     it "should not set a max-age" do
-      get_request("/statics/test").headers['Cache-Control'].must_be_nil
+      _(get_request("/statics/test").headers['Cache-Control']).must_be_nil
     end
 
     it "should not set an Expires header" do
-      get_request("/statics/test").headers['Expires'].must_be_nil
+      _(get_request("/statics/test").headers['Expires']).must_be_nil
     end
   end
 end

--- a/test/spec_rack_try_static.rb
+++ b/test/spec_rack_try_static.rb
@@ -23,24 +23,24 @@ describe "Rack::TryStatic" do
   describe 'when file cannot be found' do
     it 'should call call app' do
       res = request(build_options(:try => ['html'])).get('/statics')
-      res.ok?.must_equal(true)
-      res.body.must_equal "Hello World"
+      _(res.ok?).must_equal(true)
+      _(res.body).must_equal "Hello World"
     end
   end
 
   describe 'when file can be found' do
     it 'should serve first found' do
       res = request(build_options(:try => ['.html', '/index.html', '/index.htm'])).get('/statics')
-      res.ok?.must_equal(true)
-      res.body.strip.must_equal "index.html"
+      _(res.ok?).must_equal(true)
+      _(res.body.strip).must_equal "index.html"
     end
   end
 
   describe 'when path_info maps directly to file' do
     it 'should serve existing' do
       res = request(build_options(:try => ['/index.html'])).get('/statics/existing.html')
-      res.ok?.must_equal(true)
-      res.body.strip.must_equal "existing.html"
+      _(res.ok?).must_equal(true)
+      _(res.body.strip).must_equal "existing.html"
     end
   end
 
@@ -48,9 +48,9 @@ describe "Rack::TryStatic" do
     it 'should not mutate given options' do
       org_options = build_options  :try => ['/index.html']
       given_options = org_options.dup
-      request(given_options).get('/statics').ok?.must_equal(true)
-      request(given_options).get('/statics').ok?.must_equal(true)
-      given_options.must_equal org_options
+      _(request(given_options).get('/statics').ok?).must_equal(true)
+      _(request(given_options).get('/statics').ok?).must_equal(true)
+      _(given_options).must_equal org_options
     end
   end
 end


### PR DESCRIPTION
Changes:
- fixed failing specs
- fixed MiniTest deprecation warnings

## Notes

There were failings specs in `test/spec_rack_simple_endpoint.rb` file like this one:

```
Rack::SimpleEndpoint#test_0002_calls downstream app when path matches but method does not:
NoMethodError: undefined method `body' for ["Downstream app"]:Array
    /Users/andrykonchin/projects/rack-contrib/test/spec_rack_simple_endpoint.rb:21:in `block (2 levels) in <top (required)>'
```

The tests fail because of recent changes in Rack. In Rack 2.0.1 body is always `Rack::BodyProxy` but in the latest versions body could be not buffered and returned as Array. 

Also Minitest deprecated global usage of `must_equal` and other matchers so instead of `a.must_equal 1` following DSL should be used `_(a).must_equal 1`. Example of warning:

```
DEPRECATED: global use of must_equal from /Users/andrykonchin/projects/rack-contrib/test/spec_rack_simple_endpoint.rb:21. Use _(obj).must_equal instead. This will fail in Minitest 6.
```

## CI

Example CI build

https://travis-ci.org/github/rack/rack-contrib/builds/665654375?utm_source=github_status&utm_medium=notification