### PR TITLE
Fix Locale middleware

### DIFF
--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -22,12 +22,28 @@ module Rack
 
     private
 
-    # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
+    # Accept-Language header is covered mainly by RFC 7231
+    # https://tools.ietf.org/html/rfc7231
+    #
+    # Related sections:
+    # * https://tools.ietf.org/html/rfc7231#section-5.3.1
+    # * https://tools.ietf.org/html/rfc7231#section-5.3.5
+    #
+    # There is an obsolete RFC 2616 (https://tools.ietf.org/html/rfc2616)
+    #
+    # Edge cases:
+    #
+    # * Value can be a comma separated list with optional whitespaces:
+    #   Accept-Language: da, en-gb;q=0.8, en;q=0.7
+    #
+    # * Quality value can contain optional whitespaces as well:
+    #   Accept-Language: ru-UA, ru; q=0.8, uk; q=0.6, en-US; q=0.4, en; q=0.2
+    #
     def accept_locale(env)
       accept_langs = env["HTTP_ACCEPT_LANGUAGE"]
       return if accept_langs.nil?
 
-      languages_and_qvalues = accept_langs.split(",").map { |l|
+      languages_and_qvalues = accept_langs.gsub(/\s+/, '').split(",").map { |l|
         l += ';q=1.0' unless l =~ /;q=\d+(?:\.\d+)?$/
         l.split(';q=')
       }

--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -50,6 +50,8 @@ module Rack
 
       language_and_qvalue = languages_and_qvalues.sort_by { |(locale, qvalue)|
         qvalue.to_f
+      }.reject { |(_, qvalue)|
+        qvalue.to_f == 0
       }.reverse.detect { |(locale, qvalue)|
         if I18n.enforce_available_locales
           locale == '*' || I18n.available_locales.include?(locale.to_sym)

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -8,9 +8,10 @@ begin
   describe "Rack::Locale" do
     include Minitest::Hooks
 
-    before(:all) do
+    before do
       # Set the locales that will be used at various points in the tests
-      I18n.config.available_locales = [I18n.default_locale, :dk, :'en-gb', :es, :zh]
+      I18n.config.available_locales = [:en, :dk, :'en-gb', :es, :zh]
+      I18n.default_locale = :en
     end
 
     def app
@@ -64,6 +65,10 @@ begin
 
     specify 'should treat a * as "all other languages"' do
       _(response_with_languages('*,en;q=0.5').body).must_equal(I18n.default_locale.to_s)
+    end
+
+    specify 'should ignore languages with q=0' do
+      _(response_with_languages('dk;q=0').body).must_equal(I18n.default_locale.to_s)
     end
 
     specify 'should reset the I18n locale after the response' do

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -63,8 +63,12 @@ begin
       _(response_with_languages('en-gb,en-us;q=0.95;en').body).must_equal('en-gb')
     end
 
-    specify 'should treat a * as "all other languages"' do
-      _(response_with_languages('*,en;q=0.5').body).must_equal(I18n.default_locale.to_s)
+    specify 'should skip * if it is followed by other languages' do
+      _(response_with_languages('*,dk;q=0.5').body).must_equal('dk')
+    end
+
+    specify 'should use default locale if there is only *' do
+      _(response_with_languages('*').body).must_equal('en')
     end
 
     specify 'should ignore languages with q=0' do
@@ -84,6 +88,12 @@ begin
     specify 'should pick the available language' do
       enforce_available_locales(true) do
         _(response_with_languages('ch,en;q=0.9,es;q=0.95').body).must_equal('es')
+      end
+    end
+
+    specify 'should match languages case insensitively' do
+      enforce_available_locales(true) do
+        _(response_with_languages('EN;q=0.9,ES;q=0.95').body).must_equal('es')
       end
     end
 

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -71,6 +71,10 @@ begin
       _(response_with_languages('dk;q=0').body).must_equal(I18n.default_locale.to_s)
     end
 
+    specify 'should handle Q=' do
+      _(response_with_languages('en;Q=0.9,es;Q=0.95').body).must_equal('es')
+    end
+
     specify 'should reset the I18n locale after the response' do
       I18n.locale = :es
       response_with_languages('en,de;q=0.8')

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -50,6 +50,14 @@ begin
       _(response_with_languages('en;q=0.9,es;q=0.95').body).must_equal('es')
     end
 
+    specify 'should ignore spaces between comma separated field values' do
+      _(response_with_languages('en;q=0.9, es;q=0.95').body).must_equal('es')
+    end
+
+    specify 'should ignore spaces within quality value' do
+      _(response_with_languages('en; q=0.9,es; q=0.95').body).must_equal('es')
+    end
+
     specify 'should retain full language codes' do
       _(response_with_languages('en-gb,en-us;q=0.95;en').body).must_equal('en-gb')
     end


### PR DESCRIPTION
Fix some edge cases with handling `Accept-Language` header in the Locale middleware.

Changes:
- process correctly whitespaces
- ignore languages with `q=0`
- process correctly `Q=` prefix
- case insensitive matching

Closes https://github.com/rack/rack-contrib/issues/163