### PR TITLE
Improve tests

### DIFF
--- a/test/spec_rack_backstage.rb
+++ b/test/spec_rack_backstage.rb
@@ -5,20 +5,24 @@ require 'rack/contrib/backstage'
 
 describe "Rack::Backstage" do
   specify "shows maintenances page if present" do
-    app = Rack::Builder.new do
-      use Rack::Backstage, 'test/Maintenance.html'
-      run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
-    end
+    app = Rack::Lint.new(
+      Rack::Builder.new do
+        use Rack::Backstage, 'test/Maintenance.html'
+        run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+      end
+    )
     response = Rack::MockRequest.new(app).get('/')
     _(response.body).must_equal('Under maintenance.')
     _(response.status).must_equal(503)
   end
 
   specify "passes on request if page is not present" do
-    app = Rack::Builder.new do
-      use Rack::Backstage, 'test/Nonsense.html'
-      run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
-    end
+    app = Rack::Lint.new(
+      Rack::Builder.new do
+        use Rack::Backstage, 'test/Nonsense.html'
+        run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+      end
+    )
     response = Rack::MockRequest.new(app).get('/')
     _(response.body).must_equal('Hello, World!')
     _(response.status).must_equal(200)

--- a/test/spec_rack_bounce_favicon.rb
+++ b/test/spec_rack_bounce_favicon.rb
@@ -3,10 +3,12 @@ require 'rack/mock'
 require 'rack/contrib/bounce_favicon'
 
 describe Rack::BounceFavicon do
-  app = Rack::Builder.new do
-    use Rack::BounceFavicon
-    run lambda { |env| [200, {}, []] }
-  end
+  app = Rack::Lint.new(
+    Rack::Builder.new do
+      use Rack::BounceFavicon
+      run lambda { |env| [200, {}, []] }
+    end
+  )
 
   specify 'does nothing when requesting paths other than the favicon' do
     response = Rack::MockRequest.new(app).get('/')

--- a/test/spec_rack_callbacks.rb
+++ b/test/spec_rack_callbacks.rb
@@ -50,9 +50,11 @@ describe "Rack::Callbacks" do
       after TheEnd
     end
 
-    app = Rack::Builder.new do
-      run callback_app
-    end.to_app
+    app = Rack::Lint.new(
+      Rack::Builder.new do
+        run callback_app
+      end.to_app
+    )
 
     response = Rack::MockRequest.new(app).get("/")
 

--- a/test/spec_rack_common_cookies.rb
+++ b/test/spec_rack_common_cookies.rb
@@ -6,10 +6,12 @@ require 'rack/contrib/common_cookies'
 describe Rack::CommonCookies do
 
   before do
-    @app = Rack::Builder.new do
-      use Rack::CommonCookies
-      run lambda {|env| [200, {'Set-Cookie' => env['HTTP_COOKIE']}, []] }
-    end
+    @app = Rack::Lint.new(
+      Rack::Builder.new do
+        use Rack::CommonCookies
+        run lambda {|env| [200, {'Set-Cookie' => env['HTTP_COOKIE']}, []] }
+      end
+    )
   end
 
   def request

--- a/test/spec_rack_cookies.rb
+++ b/test/spec_rack_cookies.rb
@@ -3,51 +3,59 @@ require 'rack/mock'
 require 'rack/contrib/cookies'
 
 describe "Rack::Cookies" do
+  def cookies(app)
+    Rack::Lint.new(Rack::Cookies.new(app))
+  end
+
   specify "should be able to read received cookies" do
-    app = lambda { |env|
-      cookies = env['rack.cookies']
-      foo, quux = cookies[:foo], cookies['quux']
-      [200, {'Content-Type' => 'text/plain'}, ["foo: #{foo}, quux: #{quux}"]]
-    }
-    app = Rack::Cookies.new(app)
+    app = cookies(
+      lambda { |env|
+        cookies = env['rack.cookies']
+        foo, quux = cookies[:foo], cookies['quux']
+        [200, {'Content-Type' => 'text/plain'}, ["foo: #{foo}, quux: #{quux}"]]
+      }
+    )
 
     response = Rack::MockRequest.new(app).get('/', 'HTTP_COOKIE' => 'foo=bar;quux=h&m')
     _(response.body).must_equal('foo: bar, quux: h&m')
   end
 
   specify "should be able to set new cookies" do
-    app = lambda { |env|
-      cookies = env['rack.cookies']
-      cookies[:foo] = 'bar'
-      cookies['quux'] = 'h&m'
-      [200, {'Content-Type' => 'text/plain'}, []]
-    }
-    app = Rack::Cookies.new(app)
+    app = cookies(
+      lambda { |env|
+        cookies = env['rack.cookies']
+        cookies[:foo] = 'bar'
+        cookies['quux'] = 'h&m'
+        [200, {'Content-Type' => 'text/plain'}, []]
+      }
+    )
 
     response = Rack::MockRequest.new(app).get('/')
     _(response.headers['Set-Cookie'].split("\n").sort).must_equal(["foo=bar; path=/","quux=h%26m; path=/"])
   end
 
   specify "should be able to set cookie with options" do
-    app = lambda { |env|
-      cookies = env['rack.cookies']
-      cookies['foo'] = { :value => 'bar', :path => '/login', :secure => true }
-      [200, {'Content-Type' => 'text/plain'}, []]
-    }
-    app = Rack::Cookies.new(app)
+    app = cookies(
+      lambda { |env|
+        cookies = env['rack.cookies']
+        cookies['foo'] = { :value => 'bar', :path => '/login', :secure => true }
+        [200, {'Content-Type' => 'text/plain'}, []]
+      }
+    )
 
     response = Rack::MockRequest.new(app).get('/')
     _(response.headers['Set-Cookie']).must_equal('foo=bar; path=/login; secure')
   end
 
   specify "should be able to delete received cookies" do
-    app = lambda { |env|
-      cookies = env['rack.cookies']
-      cookies.delete(:foo)
-      foo, quux = cookies['foo'], cookies[:quux]
-      [200, {'Content-Type' => 'text/plain'}, ["foo: #{foo}, quux: #{quux}"]]
-    }
-    app = Rack::Cookies.new(app)
+    app = cookies(
+      lambda { |env|
+        cookies = env['rack.cookies']
+        cookies.delete(:foo)
+        foo, quux = cookies['foo'], cookies[:quux]
+        [200, {'Content-Type' => 'text/plain'}, ["foo: #{foo}, quux: #{quux}"]]
+      }
+    )
 
     response = Rack::MockRequest.new(app).get('/', 'HTTP_COOKIE' => 'foo=bar;quux=h&m')
     _(response.body).must_equal('foo: , quux: h&m')

--- a/test/spec_rack_csshttprequest.rb
+++ b/test/spec_rack_csshttprequest.rb
@@ -6,6 +6,9 @@ begin
   require 'rack/contrib/csshttprequest'
 
   describe "Rack::CSSHTTPRequest" do
+    def css_httl_request(app)
+      Rack::Lint.new(Rack::CSSHTTPRequest.new(app))
+    end
 
     before(:each) do
       @test_body = '{"bar":"foo"}'
@@ -16,43 +19,43 @@ begin
 
     specify "env['csshttprequest.chr'] should be set to true when \
         PATH_INFO ends with '.chr'" do
-      request = Rack::MockRequest.env_for("/blah.chr", :lint => true, :fatal => true)
-      Rack::CSSHTTPRequest.new(@app).call(request)
+      request = Rack::MockRequest.env_for("/blah.chr", :fatal => true)
+      css_httl_request(@app).call(request)
       _(request['csshttprequest.chr']).must_equal true
     end
 
     specify "env['csshttprequest.chr'] should be set to true when \
         request parameter _format == 'chr'" do
-      request = Rack::MockRequest.env_for("/?_format=chr", :lint => true, :fatal => true)
-      Rack::CSSHTTPRequest.new(@app).call(request)
+      request = Rack::MockRequest.env_for("/?_format=chr", :fatal => true)
+      css_httl_request(@app).call(request)
       _(request['csshttprequest.chr']).must_equal true
     end
 
     specify "should not change the headers or response when !env['csshttprequest.chr']" do
-      request = Rack::MockRequest.env_for("/", :lint => true, :fatal => true)
-      status, headers, response = Rack::CSSHTTPRequest.new(@app).call(request)
+      request = Rack::MockRequest.env_for("/", :fatal => true)
+      status, headers, body = css_httl_request(@app).call(request)
       _(headers).must_equal @test_headers
-      _(response.join).must_equal @test_body
+      _(body.to_enum.to_a.join).must_equal @test_body
     end
 
     describe "when env['csshttprequest.chr']" do
       before(:each) do
         @request = Rack::MockRequest.env_for("/",
-          'csshttprequest.chr' => true, :lint => true, :fatal => true)
+          'csshttprequest.chr' => true, :fatal => true)
       end
 
       specify "should modify the content length to the correct value" do
-        headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
+        headers = css_httl_request(@app).call(@request)[1]
         _(headers['Content-Length']).must_equal @encoded_body.length.to_s
       end
 
       specify "should modify the content type to the correct value" do
-        headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
+        headers = css_httl_request(@app).call(@request)[1]
         _(headers['Content-Type']).must_equal 'text/css'
       end
 
       specify "should not modify any other headers" do
-        headers = Rack::CSSHTTPRequest.new(@app).call(@request)[1]
+        headers = css_httl_request(@app).call(@request)[1]
         _(headers).must_equal @test_headers.merge({
           'Content-Type' => 'text/css',
           'Content-Length' => @encoded_body.length.to_s

--- a/test/spec_rack_deflect.rb
+++ b/test/spec_rack_deflect.rb
@@ -67,7 +67,7 @@ describe "Rack::Deflect" do
     _(body.to_enum.to_a).must_equal []
 
     # Move to the future so the block will expire
-    Time.stub :now, Time.now + 3 do
+    Timecop.travel(Time.now + 3) do
       # Another 5 is fine now
       5.times do
         status, headers, body = app.call env

--- a/test/spec_rack_deflect.rb
+++ b/test/spec_rack_deflect.rb
@@ -16,14 +16,14 @@ describe "Rack::Deflect" do
   end
 
   def mock_deflect options = {}
-    Rack::Deflect.new @app, options
+    Rack::Lint.new(Rack::Deflect.new(@app, options))
   end
 
   specify "should allow regular requests to follow through" do
     app = mock_deflect
     status, headers, body = app.call mock_env(@mock_addr_1)
     _(status).must_equal 200
-    _(body).must_equal ['cookies']
+    _(body.to_enum.to_a).must_equal ['cookies']
   end
 
   specify "should deflect requests exceeding the request threshold" do
@@ -35,14 +35,14 @@ describe "Rack::Deflect" do
     5.times do
       status, headers, body = app.call env
       _(status).must_equal 200
-      _(body).must_equal ['cookies']
+      _(body.to_enum.to_a).must_equal ['cookies']
     end
 
     # Remaining requests should fail for 10 seconds
     10.times do
       status, headers, body = app.call env
       _(status).must_equal 403
-      _(body).must_equal []
+      _(body.to_enum.to_a).must_equal []
     end
 
     # Log should reflect that we have blocked an address
@@ -58,13 +58,13 @@ describe "Rack::Deflect" do
     5.times do
       status, headers, body = app.call env
       _(status).must_equal 200
-      _(body).must_equal ['cookies']
+      _(body.to_enum.to_a).must_equal ['cookies']
     end
 
     # Exceeds request threshold
     status, headers, body = app.call env
     _(status).must_equal 403
-    _(body).must_equal []
+    _(body.to_enum.to_a).must_equal []
 
     # Move to the future so the block will expire
     Time.stub :now, Time.now + 3 do
@@ -72,7 +72,7 @@ describe "Rack::Deflect" do
       5.times do
         status, headers, body = app.call env
         _(status).must_equal 200
-        _(body).must_equal ['cookies']
+        _(body.to_enum.to_a).must_equal ['cookies']
       end
     end
 
@@ -88,7 +88,7 @@ describe "Rack::Deflect" do
     10.times do
       status, headers, body = app.call env
       _(status).must_equal 200
-      _(body).must_equal ['cookies']
+      _(body.to_enum.to_a).must_equal ['cookies']
     end
   end
 
@@ -97,11 +97,11 @@ describe "Rack::Deflect" do
 
     status, headers, body = app.call mock_env(@mock_addr_1)
     _(status).must_equal 200
-    _(body).must_equal ['cookies']
+    _(body.to_enum.to_a).must_equal ['cookies']
 
     status, headers, body = app.call mock_env(@mock_addr_2)
     _(status).must_equal 403
-    _(body).must_equal []
+    _(body.to_enum.to_a).must_equal []
   end
 
 end

--- a/test/spec_rack_enforce_valid_encoding.rb
+++ b/test/spec_rack_enforce_valid_encoding.rb
@@ -12,9 +12,13 @@ if "a string".respond_to?(:valid_encoding?)
 
   describe "Rack::EnforceValidEncoding" do
     before do
-      @app = Rack::EnforceValidEncoding.new(lambda { |env|
-        [200, {'Content-Type'=>'text/plain'}, ['Hello World']]
-      })
+      @app = Rack::Lint.new(
+        Rack::EnforceValidEncoding.new(
+          lambda do |env|
+            [200, {'Content-Type'=>'text/plain'}, ['Hello World']]
+          end
+        )
+      )
     end
 
     describe "contstant assertions" do

--- a/test/spec_rack_evil.rb
+++ b/test/spec_rack_evil.rb
@@ -5,15 +5,17 @@ require 'erb'
 
 describe "Rack::Evil" do
   app = lambda do |env|
-    template = ERB.new("<%= throw :response, [404, {'Content-Type' => 'text/html'}, 'Never know where it comes from'] %>")
+    template = ERB.new("<%= throw :response, [404, {'Content-Type' => 'text/html'}, ['Never know where it comes from']] %>")
     [200, {'Content-Type' => 'text/plain'}, template.result(binding)]
   end
 
+  env = Rack::MockRequest.env_for('', {})
+
   specify "should enable the app to return the response from anywhere" do
-    status, headers, body = Rack::Evil.new(app).call({})
+    status, headers, body = Rack::Lint.new(Rack::Evil.new(app)).call(env)
 
     _(status).must_equal 404
     _(headers['Content-Type']).must_equal 'text/html'
-    _(body).must_equal 'Never know where it comes from'
+    _(body.to_enum.to_a).must_equal ['Never know where it comes from']
   end
 end

--- a/test/spec_rack_garbagecollector.rb
+++ b/test/spec_rack_garbagecollector.rb
@@ -7,7 +7,7 @@ describe 'Rack::GarbageCollector' do
   specify 'starts the garbage collector after each request' do
     app = lambda { |env|
       [200, {'Content-Type'=>'text/plain'}, ['Hello World']] }
-    Rack::GarbageCollector.new(app).call({})
+    Rack::Lint.new(Rack::GarbageCollector.new(app).call({}))
   end
 
 end

--- a/test/spec_rack_json_body_parser_spec.rb
+++ b/test/spec_rack_json_body_parser_spec.rb
@@ -24,36 +24,36 @@ describe Rack::JSONBodyParser do
 
   specify "should parse 'application/json' requests" do
     res = create_parser(app).call(mock_env)
-    res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
+    _(res[2].to_enum.to_a.join).must_equal '{"key"=>"value"}'
   end
 
   specify "should parse 'application/json; charset=utf-8' requests" do
     env = mock_env(type: 'application/json; charset=utf-8')
     res = create_parser(app).call(env)
-    res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
+    _(res[2].to_enum.to_a.join).must_equal '{"key"=>"value"}'
   end
 
   specify "should parse 'application/json' requests with an empty body" do
     res = create_parser(app).call(mock_env(input: ''))
-    res[2].to_enum.to_a.join.must_equal '{}'
+    _(res[2].to_enum.to_a.join).must_equal '{}'
   end
 
   specify "shouldn't affect form-urlencoded requests" do
     env = mock_env(input: 'key=value', type: 'application/x-www-form-urlencoded')
     res = create_parser(app).call(env)
-    res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
+    _(res[2].to_enum.to_a.join).must_equal '{"key"=>"value"}'
   end
 
   specify "should not parse non-json media types" do
     env = mock_env(type: 'text/plain')
     res = create_parser(app).call(env)
-    res[2].to_enum.to_a.join.must_equal '{}'
+    _(res[2].to_enum.to_a.join).must_equal '{}'
   end
 
   specify "shouldn't parse or error when CONTENT_TYPE is nil" do
     env = mock_env(type: nil)
     res = create_parser(app).call(env)
-    res[2].to_enum.to_a.join.must_equal %Q({"{\\"key\\": \\"value\\"}"=>nil})
+    _(res[2].to_enum.to_a.join).must_equal %Q({"{\\"key\\": \\"value\\"}"=>nil})
   end
 
   specify "should not create additions" do
@@ -61,16 +61,16 @@ describe Rack::JSONBodyParser do
     env = mock_env(input: %{{"json_class":"this_should_not_be_added"}})
     create_parser(app).call(env)
     result = Symbol.all_symbols - before
-    result.must_be_empty
+    _(result).must_be_empty
   end
 
   describe "contradiction between body and type" do
     specify "should return bad request with a JSON-encoded error message" do
       env = mock_env(input: 'This is not JSON')
       status, headers, body = create_parser(app).call(env)
-      status.must_equal 400
-      headers['Content-Type'].must_equal 'application/json'
-      body.each { |part| JSON.parse(part)['error'].wont_be_nil }
+      _(status).must_equal 400
+      _(headers['Content-Type']).must_equal 'application/json'
+      body.each { |part| _(JSON.parse(part)['error']).wont_be_nil }
     end
   end
 
@@ -80,7 +80,7 @@ describe Rack::JSONBodyParser do
         { 'payload' => JSON.parse(body) }
       end
       res = parser.call(mock_env)
-      res[2].to_enum.to_a.join.must_equal '{"payload"=>{"key"=>"value"}}'
+      _(res[2].to_enum.to_a.join).must_equal '{"payload"=>{"key"=>"value"}}'
     end
 
     specify "should accept an array of HTTP verbs to parse" do
@@ -88,35 +88,35 @@ describe Rack::JSONBodyParser do
       parser = create_parser(app, verbs: %w[GET])
 
       res = parser.call(env)
-      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
+      _(res[2].to_enum.to_a.join).must_equal '{"key"=>"value"}'
 
       res = parser.call(mock_env)
-      res[2].to_enum.to_a.join.must_equal '{}'
+      _(res[2].to_enum.to_a.join).must_equal '{}'
     end
 
     specify "should accept an Array of media-types to parse" do
       parser = create_parser(app, media: ['application/json', 'text/plain'])
       env = mock_env(type: 'text/plain')
       res = parser.call(env)
-      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
+      _(res[2].to_enum.to_a.join).must_equal '{"key"=>"value"}'
 
       html_env = mock_env(type: 'text/html')
       res = parser.call(html_env)
-      res[2].to_enum.to_a.join.must_equal '{}'
+      _(res[2].to_enum.to_a.join).must_equal '{}'
     end
 
     specify "should accept a Regexp as a media-type matcher" do
       parser = create_parser(app, media: /json/)
       env = mock_env(type: 'weird/json.odd')
       res = parser.call(env)
-      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
+      _(res[2].to_enum.to_a.join).must_equal '{"key"=>"value"}'
     end
 
     specify "should accept a String as a media-type matcher" do
       parser = create_parser(app, media: 'application/vnd.api+json')
       env = mock_env(type: 'application/vnd.api+json')
       res = parser.call(env)
-      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
+      _(res[2].to_enum.to_a.join).must_equal '{"key"=>"value"}'
     end
   end
 end

--- a/test/spec_rack_json_body_parser_spec.rb
+++ b/test/spec_rack_json_body_parser_spec.rb
@@ -3,59 +3,63 @@ require 'rack/mock'
 require 'rack/contrib/json_body_parser'
 
 describe Rack::JSONBodyParser do
-  APP = ->(env) { Rack::Request.new(env).params }
-
-  def mock_env(input: '{"key": "value"}', type: 'application/json')
-    Rack::MockRequest.env_for '/', input: input, 'REQUEST_METHOD' => 'POST',
-      'CONTENT_TYPE' => type
-  end
-
-  def create_parser(**args, &block)
-    Rack::JSONBodyParser.new(APP, **args, &block)
-  end
 
   def app
-    ->(env) { Rack::Request.new(env).POST }
+   ->(env) { [200, {}, [Rack::Request.new(env).params.to_s]] }
+  end
+
+  def mock_env(input: '{"key": "value"}', type: 'application/json')
+    headers = if type
+                { input: input, 'REQUEST_METHOD' => 'POST', 'CONTENT_TYPE' => type }
+              else
+                { input: input, 'REQUEST_METHOD' => 'POST' }
+              end
+
+    Rack::MockRequest.env_for '/', headers
+  end
+
+  def create_parser(app, **args, &block)
+    Rack::Lint.new(Rack::JSONBodyParser.new(app, **args, &block))
   end
 
   specify "should parse 'application/json' requests" do
-    res = create_parser.call(mock_env)
-    res['key'].must_equal "value"
+    res = create_parser(app).call(mock_env)
+    res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
   end
 
   specify "should parse 'application/json; charset=utf-8' requests" do
     env = mock_env(type: 'application/json; charset=utf-8')
-    res = create_parser.call(env)
-    res['key'].must_equal "value"
+    res = create_parser(app).call(env)
+    res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
   end
 
   specify "should parse 'application/json' requests with an empty body" do
-    res = create_parser.call(mock_env(input: ''))
-    res.must_equal({})
+    res = create_parser(app).call(mock_env(input: ''))
+    res[2].to_enum.to_a.join.must_equal '{}'
   end
 
   specify "shouldn't affect form-urlencoded requests" do
     env = mock_env(input: 'key=value', type: 'application/x-www-form-urlencoded')
-    res = create_parser.call(env)
-    res['key'].must_equal "value"
+    res = create_parser(app).call(env)
+    res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
   end
 
   specify "should not parse non-json media types" do
     env = mock_env(type: 'text/plain')
-    res = create_parser.call(env)
-    res['key'].must_be_nil
+    res = create_parser(app).call(env)
+    res[2].to_enum.to_a.join.must_equal '{}'
   end
 
   specify "shouldn't parse or error when CONTENT_TYPE is nil" do
     env = mock_env(type: nil)
-    res = create_parser.call(env)
-    assert_nil(res['key'])
+    res = create_parser(app).call(env)
+    res[2].to_enum.to_a.join.must_equal %Q({"{\\"key\\": \\"value\\"}"=>nil})
   end
 
   specify "should not create additions" do
     before = Symbol.all_symbols
     env = mock_env(input: %{{"json_class":"this_should_not_be_added"}})
-    res = create_parser.call(env)
+    create_parser(app).call(env)
     result = Symbol.all_symbols - before
     result.must_be_empty
   end
@@ -63,7 +67,7 @@ describe Rack::JSONBodyParser do
   describe "contradiction between body and type" do
     specify "should return bad request with a JSON-encoded error message" do
       env = mock_env(input: 'This is not JSON')
-      status, headers, body = create_parser.call(env)
+      status, headers, body = create_parser(app).call(env)
       status.must_equal 400
       headers['Content-Type'].must_equal 'application/json'
       body.each { |part| JSON.parse(part)['error'].wont_be_nil }
@@ -72,48 +76,47 @@ describe Rack::JSONBodyParser do
 
   describe "with configuration" do
     specify "should use a given block to parse the JSON body" do
-      parser = create_parser do |body|
+      parser = create_parser(app) do |body|
         { 'payload' => JSON.parse(body) }
       end
       res = parser.call(mock_env)
-      res['payload'].wont_be_nil
-      res['payload']['key'].must_equal "value"
+      res[2].to_enum.to_a.join.must_equal '{"payload"=>{"key"=>"value"}}'
     end
 
     specify "should accept an array of HTTP verbs to parse" do
       env = mock_env.merge('REQUEST_METHOD' => 'GET')
-      parser = create_parser(verbs: %w[GET])
+      parser = create_parser(app, verbs: %w[GET])
 
-      res_via_get = parser.call(env)
-      res_via_post = parser.call(mock_env)
+      res = parser.call(env)
+      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
 
-      res_via_get['key'].must_equal 'value'
-      res_via_post['key'].must_be_nil
+      res = parser.call(mock_env)
+      res[2].to_enum.to_a.join.must_equal '{}'
     end
 
     specify "should accept an Array of media-types to parse" do
-      parser = create_parser(media: ['application/json', 'text/plain'])
+      parser = create_parser(app, media: ['application/json', 'text/plain'])
       env = mock_env(type: 'text/plain')
       res = parser.call(env)
-      res['key'].must_equal 'value'
+      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
 
       html_env = mock_env(type: 'text/html')
-      html_res = parser.call(html_env)
-      html_res['key'].must_be_nil
+      res = parser.call(html_env)
+      res[2].to_enum.to_a.join.must_equal '{}'
     end
 
     specify "should accept a Regexp as a media-type matcher" do
-      parser = create_parser(media: /json/)
+      parser = create_parser(app, media: /json/)
       env = mock_env(type: 'weird/json.odd')
       res = parser.call(env)
-      res['key'].must_equal 'value'
+      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
     end
 
     specify "should accept a String as a media-type matcher" do
-      parser = create_parser(media: 'application/vnd.api+json')
+      parser = create_parser(app, media: 'application/vnd.api+json')
       env = mock_env(type: 'application/vnd.api+json')
       res = parser.call(env)
-      res['key'].must_equal 'value'
+      res[2].to_enum.to_a.join.must_equal '{"key"=>"value"}'
     end
   end
 end

--- a/test/spec_rack_lazy_conditional_get.rb
+++ b/test/spec_rack_lazy_conditional_get.rb
@@ -34,7 +34,7 @@ describe 'Rack::LazyConditionalGet' do
   let(:rack_lazy_conditional_get) { 'yes' }
 
   let(:app) {
-    Rack::LazyConditionalGet.new core_app, $lazy_conditional_get_cache
+    Rack::Lint.new(Rack::LazyConditionalGet.new core_app, $lazy_conditional_get_cache)
   }
 
   let(:env) {

--- a/test/spec_rack_lighttpd_script_name_fix.rb
+++ b/test/spec_rack_lighttpd_script_name_fix.rb
@@ -4,12 +4,15 @@ require 'rack/contrib/lighttpd_script_name_fix'
 
 describe "Rack::LighttpdScriptNameFix" do
   specify "corrects SCRIPT_NAME and PATH_INFO set by lighttpd " do
-    env = {
-      "PATH_INFO" => "/foo/bar/baz",
-      "SCRIPT_NAME" => "/hello"
-    }
+    env = Rack::MockRequest.env_for(
+      '',
+      {
+        "PATH_INFO" => "/foo/bar/baz",
+        "SCRIPT_NAME" => "/hello"
+      }
+    )
     app = lambda { |_| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
-    response = Rack::LighttpdScriptNameFix.new(app).call(env)
+    response = Rack::Lint.new(Rack::LighttpdScriptNameFix.new(app)).call(env)
     _(env['SCRIPT_NAME'].empty?).must_equal(true)
     _(env['PATH_INFO']).must_equal '/hello/foo/bar/baz'
   end

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -15,14 +15,20 @@ begin
     end
 
     def app
-      @app ||= Rack::Builder.new do
-        use Rack::Locale
-        run lambda { |env| [ 200, {}, [ I18n.locale.to_s ] ] }
-      end
+      @app ||= Rack::Lint.new(
+        Rack::Builder.new do
+          use Rack::Locale
+          run lambda { |env| [ 200, {}, [ I18n.locale.to_s ] ] }
+        end
+      )
     end
 
     def response_with_languages(accept_languages)
-      Rack::MockRequest.new(app).get('/', { 'HTTP_ACCEPT_LANGUAGE' => accept_languages } )
+      if accept_languages
+        Rack::MockRequest.new(app).get('/', { 'HTTP_ACCEPT_LANGUAGE' => accept_languages } )
+      else
+        Rack::MockRequest.new(app).get('/', {})
+      end
     end
 
     def enforce_available_locales(enforce)

--- a/test/spec_rack_proctitle.rb
+++ b/test/spec_rack_proctitle.rb
@@ -6,17 +6,21 @@ describe "Rack::ProcTitle" do
   progname = ::File.basename($0)
   appname = ::File.expand_path(__FILE__).split('/')[-3]
 
+  def proc_title(app)
+    Rack::Lint.new(Rack::ProcTitle.new(app))
+  end
+
   def simple_app(body=['Hello World!'])
     lambda { |env| [200, {'Content-Type' => 'text/plain'}, body] }
   end
 
   specify "should set the process title when created" do
-    Rack::ProcTitle.new(simple_app)
+    proc_title(simple_app)
     _($0).must_equal "#{progname} [#{appname}] init ..."
   end
 
   specify "should set the process title on each request" do
-    app = Rack::ProcTitle.new(simple_app)
+    app = proc_title(simple_app)
     req = Rack::MockRequest.new(app)
     10.times { req.get('/hello') }
     _($0).must_equal "#{progname} [#{appname}/80] (10) GET /hello"

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -5,35 +5,39 @@ begin
   require 'rack/contrib/profiler'
 
   describe 'Rack::Profiler' do
-    app = lambda { |env| Time.new; [200, {'Content-Type' => 'text/plain'}, 'Oh hai der'] }
+    app = lambda { |env| Time.new; [200, {'Content-Type' => 'text/plain'}, ['Oh hai der']] }
     request = Rack::MockRequest.env_for("/", :params => "profile=process_time")
 
+    def profiler(app, options = {})
+      Rack::Lint.new(Rack::Profiler.new(app, options))
+    end
+
     specify 'printer defaults to RubyProf::CallStackPrinter' do
-      profiler = Rack::Profiler.new(nil)
+      profiler = Rack::Profiler.new(nil, {}) # Don't use Rack::Lint to haev access to the middleware instance variable
       _(profiler.instance_variable_get('@printer')).must_equal RubyProf::CallStackPrinter
       _(profiler.instance_variable_get('@times')).must_equal 1
     end
 
     specify 'called multiple times via query params' do
       req = Rack::MockRequest.env_for("/", :params => "profile=process_time&profiler_runs=4")
-      body = Rack::Profiler.new(app).call(req)[2].string
-      _(body).must_match(/Time#initialize \[4 calls, 4 total\]/)
+      body = profiler(app).call(req)[2]
+      _(body.to_enum.to_a.join).must_match(/Time#initialize \[4 calls, 4 total\]/)
     end
 
     specify 'CallStackPrinter has Content-Type test/html' do
-      headers = Rack::Profiler.new(app, :printer => :call_stack).call(request)[1]
+      headers = profiler(app, :printer => :call_stack).call(request)[1]
       _(headers).must_equal "Content-Type"=>"text/html"
     end
 
     specify 'FlatPrinter and GraphPrinter has Content-Type text/plain' do
       %w(flat graph).each do |printer|
-        headers = Rack::Profiler.new(app, :printer => printer.to_sym).call(request)[1]
+        headers = profiler(app, :printer => printer.to_sym).call(request)[1]
         _(headers).must_equal "Content-Type"=>"text/plain"
       end
     end
 
     specify 'GraphHtmlPrinter has Content-Type text/html' do
-      headers = Rack::Profiler.new(app, :printer => :graph_html).call(request)[1]
+      headers = profiler(app, :printer => :graph_html).call(request)[1]
       _(headers).must_equal "Content-Type"=>"text/html"
     end
   end

--- a/test/spec_rack_relative_redirect.rb
+++ b/test/spec_rack_relative_redirect.rb
@@ -7,7 +7,7 @@ describe Rack::RelativeRedirect do
   def request(opts={}, &block)
     @def_status = opts[:status] if opts[:status]
     @def_location = opts[:location] if opts[:location]
-    yield Rack::MockRequest.new(Rack::RelativeRedirect.new(@def_app, &opts[:block])).get(opts[:path]||@def_path, opts[:headers]||{})
+    yield Rack::MockRequest.new(Rack::Lint.new(Rack::RelativeRedirect.new(@def_app, &opts[:block]))).get(opts[:path]||@def_path, opts[:headers]||{})
   end
 
   before do

--- a/test/spec_rack_response_cache.rb
+++ b/test/spec_rack_response_cache.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 
 describe Rack::ResponseCache do
   def request(opts={}, &block)
-    Rack::MockRequest.new(Rack::ResponseCache.new(block||@def_app, opts[:cache]||@cache, &opts[:rc_block])).send(opts[:meth]||:get, opts[:path]||@def_path, opts[:headers]||{})
+    Rack::MockRequest.new(Rack::Lint.new(Rack::ResponseCache.new(block||@def_app, opts[:cache]||@cache, &opts[:rc_block]))).send(opts[:meth]||:get, opts[:path]||@def_path, opts[:headers]||{})
   end
 
   before do
@@ -136,7 +136,7 @@ describe Rack::ResponseCache do
   end
 
   specify "should raise an error if a cache argument is not provided" do
-    app = Rack::Builder.new{use Rack::ResponseCache; run lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::Request.new(env).POST]}}
+    app = Rack::Lint.new(Rack::Builder.new{use Rack::ResponseCache; run lambda { |env| [200, {'Content-Type' => 'text/plain'}, []]}})
     _(proc{Rack::MockRequest.new(app).get('/')}).must_raise(ArgumentError)
   end
 

--- a/test/spec_rack_response_headers.rb
+++ b/test/spec_rack_response_headers.rb
@@ -3,32 +3,39 @@ require 'rack'
 require 'rack/contrib/response_headers'
 
 describe "Rack::ResponseHeaders" do
+  def response_header(app, &block)
+    Rack::Lint.new(Rack::ResponseHeaders.new(app, &block))
+  end
+
+  def env
+    Rack::MockRequest.env_for('', {})
+  end
 
   specify "yields a HeaderHash of response headers" do
     orig_headers = {'X-Foo' => 'foo', 'X-Bar' => 'bar'}
     app = Proc.new {[200, orig_headers, []]}
-    middleware = Rack::ResponseHeaders.new(app) do |headers|
+    middleware = response_header(app) do |headers|
       assert_instance_of Rack::Utils::HeaderHash, headers
       _(orig_headers).must_equal headers
     end
-    middleware.call({})
+    middleware.call(env)
   end
 
   specify "allows adding headers" do
     app = Proc.new {[200, {'X-Foo' => 'foo'}, []]}
-    middleware = Rack::ResponseHeaders.new(app) do |headers|
+    middleware = response_header(app) do |headers|
       headers['X-Bar'] = 'bar'
     end
-    r = middleware.call({})
+    r = middleware.call(env)
     _(r[1]).must_equal('X-Foo' => 'foo', 'X-Bar' => 'bar')
   end
 
   specify "allows deleting headers" do
     app = Proc.new {[200, {'X-Foo' => 'foo', 'X-Bar' => 'bar'}, []]}
-    middleware = Rack::ResponseHeaders.new(app) do |headers|
+    middleware = response_header(app) do |headers|
       headers.delete('X-Bar')
     end
-    r = middleware.call({})
+    r = middleware.call(env)
     _(r[1]).must_equal('X-Foo' => 'foo')
   end
 

--- a/test/spec_rack_simple_endpoint.rb
+++ b/test/spec_rack_simple_endpoint.rb
@@ -7,62 +7,61 @@ describe "Rack::SimpleEndpoint" do
     @app = Proc.new { Rack::Response.new {|r| r.write "Downstream app"}.finish }
   end
 
-  # We use the thick with body `body.to_enum.to_a` instead of checking a body
-  # directly only because the tests suite can be run against different versions
-  # of Rack. Some versions can return Rack::BodyProxy instead of simple
-  # array
+  def simple_endpoint(app, params, &block)
+    Rack::Lint.new(Rack::SimpleEndpoint.new(app, params, &block))
+  end
 
   specify "calls downstream app when no match" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { 'bar' }
+    endpoint = simple_endpoint(@app, '/foo') { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/baz'))
     _(status).must_equal 200
     _(body.to_enum.to_a).must_equal ['Downstream app']
   end
 
   specify "calls downstream app when path matches but method does not" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => :get) { 'bar' }
+    endpoint = simple_endpoint(@app, '/foo' => :get) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo', :method => 'post'))
     _(status).must_equal 200
     _(body.to_enum.to_a).must_equal ['Downstream app']
   end
 
   specify "calls downstream app when path matches but block returns :pass" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { :pass }
+    endpoint = simple_endpoint(@app, '/foo') { :pass }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
     _(body.to_enum.to_a).must_equal ['Downstream app']
   end
 
   specify "returns endpoint response when path matches" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo') { 'bar' }
+    endpoint = simple_endpoint(@app, '/foo') { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
     _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "returns endpoint response when path and single method requirement match" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => :get) { 'bar' }
+    endpoint = simple_endpoint(@app, '/foo' => :get) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
     _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "returns endpoint response when path and one of multiple method requirements match" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo' => [:get, :post]) { 'bar' }
+    endpoint = simple_endpoint(@app, '/foo' => [:get, :post]) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo', :method => 'post'))
     _(status).must_equal 200
     _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "returns endpoint response when path matches regex" do
-    endpoint = Rack::SimpleEndpoint.new(@app, /foo/) { 'bar' }
+    endpoint = simple_endpoint(@app, /foo/) { 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/bar/foo'))
     _(status).must_equal 200
     _(body.to_enum.to_a).must_equal ['bar']
   end
 
   specify "block yields Rack::Request and Rack::Response objects" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo') do |req, res|
+    endpoint = simple_endpoint(@app, '/foo') do |req, res|
       assert_instance_of ::Rack::Request, req
       assert_instance_of ::Rack::Response, res
     end
@@ -70,7 +69,7 @@ describe "Rack::SimpleEndpoint" do
   end
 
   specify "block yields MatchData object when Regex path matcher specified" do
-    endpoint = Rack::SimpleEndpoint.new(@app, /foo(.+)/) do |req, res, match|
+    endpoint = simple_endpoint(@app, /foo(.+)/) do |req, res, match|
       assert_instance_of MatchData, match
       assert_equal 'bar', match[1]
     end
@@ -78,14 +77,14 @@ describe "Rack::SimpleEndpoint" do
   end
 
   specify "block does NOT yield MatchData object when String path matcher specified" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo') do |req, res, match|
+    endpoint = simple_endpoint(@app, '/foo') do |req, res, match|
       assert_nil match
     end
     endpoint.call(Rack::MockRequest.env_for('/foo'))
   end
 
   specify "response honors headers set in block" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo') {|req, res| res['X-Foo'] = 'bar'; 'baz' }
+    endpoint = simple_endpoint(@app, '/foo') {|req, res| res['X-Foo'] = 'bar'; 'baz' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(status).must_equal 200
     _(headers['X-Foo']).must_equal 'bar'
@@ -93,7 +92,7 @@ describe "Rack::SimpleEndpoint" do
   end
 
   specify "sets Content-Length header" do
-    endpoint = Rack::SimpleEndpoint.new(@app, '/foo') {|req, res| 'bar' }
+    endpoint = simple_endpoint(@app, '/foo') {|req, res| 'bar' }
     status, headers, body = endpoint.call(Rack::MockRequest.env_for('/foo'))
     _(headers['Content-Length']).must_equal '3'
   end

--- a/test/spec_rack_static_cache.rb
+++ b/test/spec_rack_static_cache.rb
@@ -22,7 +22,7 @@ describe "Rack::StaticCache" do
 
   def build_middleware(options)
     options = { :root => static_root }.merge(options)
-    Rack::StaticCache.new(DummyApp.new, options)
+    Rack::Lint.new(Rack::StaticCache.new(DummyApp.new, options))
   end
 
   describe "with a default app request" do

--- a/test/spec_rack_try_static.rb
+++ b/test/spec_rack_try_static.rb
@@ -14,9 +14,10 @@ end
 def request(options = {})
   @request =
     Rack::MockRequest.new(
-      Rack::TryStatic.new(
-        lambda { |_| [200, {}, ["Hello World"]]},
-        options))
+      Rack::Lint.new(
+        Rack::TryStatic.new(
+          lambda { |_| [200, {}, ["Hello World"]]},
+          options)))
 end
 
 describe "Rack::TryStatic" do


### PR DESCRIPTION
Changes:
- use `Rack::Lint` where it's missing
- fixed MiniTest deprecation warnings in the added recently `JSONBodyParser` middleware
- use `Timecop` where it's appropriate