### PR TITLE
Use frozen_string_literal magic comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # -*-ruby-*-
 exec(*(["bundle", "exec", $PROGRAM_NAME] + ARGV)) if ENV['BUNDLE_GEMFILE'].nil?
 

--- a/lib/rack/contrib.rb
+++ b/lib/rack/contrib.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack'
 
 module Rack

--- a/lib/rack/contrib/access.rb
+++ b/lib/rack/contrib/access.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ipaddr"
 
 module Rack

--- a/lib/rack/contrib/backstage.rb
+++ b/lib/rack/contrib/backstage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class Backstage
     File = ::File

--- a/lib/rack/contrib/bounce_favicon.rb
+++ b/lib/rack/contrib/bounce_favicon.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Bounce those annoying favicon.ico requests
   class BounceFavicon

--- a/lib/rack/contrib/callbacks.rb
+++ b/lib/rack/contrib/callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class Callbacks
     def initialize(&block)

--- a/lib/rack/contrib/common_cookies.rb
+++ b/lib/rack/contrib/common_cookies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Rack middleware to use common cookies across domain and subdomains.
   class CommonCookies

--- a/lib/rack/contrib/config.rb
+++ b/lib/rack/contrib/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
 
   # Rack::Config modifies the environment using the block given during

--- a/lib/rack/contrib/cookies.rb
+++ b/lib/rack/contrib/cookies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class Cookies
     class CookieJar < Hash

--- a/lib/rack/contrib/csshttprequest.rb
+++ b/lib/rack/contrib/csshttprequest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'csshttprequest'
 
 module Rack

--- a/lib/rack/contrib/csshttprequest.rb
+++ b/lib/rack/contrib/csshttprequest.rb
@@ -27,9 +27,8 @@ module Rack
         !(/\.chr$/.match(env['PATH_INFO'])).nil? || Rack::Request.new(env).params['_format'] == 'chr'
     end
 
-    def encode(response, assembled_body="")
-      response.each { |s| assembled_body << s.to_s } # call down the stack
-      return ::CSSHTTPRequest.encode(assembled_body)
+    def encode(body)
+      ::CSSHTTPRequest.encode(body.to_enum.to_a.join)
     end
 
     def modify_headers!(headers, encoded_response)

--- a/lib/rack/contrib/deflect.rb
+++ b/lib/rack/contrib/deflect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 # TODO: optional stats

--- a/lib/rack/contrib/enforce_valid_encoding.rb
+++ b/lib/rack/contrib/enforce_valid_encoding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Ensure that the path and query string presented to the application
   # contains only valid characters.  If the validation fails, then a

--- a/lib/rack/contrib/evil.rb
+++ b/lib/rack/contrib/evil.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class Evil
     # Lets you return a response to the client immediately from anywhere ( M V or C ) in the code.

--- a/lib/rack/contrib/expectation_cascade.rb
+++ b/lib/rack/contrib/expectation_cascade.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class ExpectationCascade
     Expect = "Expect".freeze

--- a/lib/rack/contrib/garbagecollector.rb
+++ b/lib/rack/contrib/garbagecollector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Forces garbage collection after each request.
   class GarbageCollector

--- a/lib/rack/contrib/host_meta.rb
+++ b/lib/rack/contrib/host_meta.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
 
   # Rack middleware implementing the IETF draft: "Host Metadata for the Web"

--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -89,8 +89,8 @@ module Rack
     # method of combining all of the data into a single string makes sense
     # since JSON is returned as a full string.
     #
-    def pad(callback, response, body = "")
-      response.each do |s|
+    def pad(callback, response)
+      body = response.to_enum.map do |s|
         # U+2028 and U+2029 are allowed inside strings in JSON (as all literal
         # Unicode characters) but JavaScript defines them as newline
         # seperators. Because no literal newlines are allowed in a string, this
@@ -98,8 +98,8 @@ module Rack
         # replacing them with the escaped version. This should be safe because
         # according to the JSON spec, these characters are *only* valid inside
         # a string and should therefore not be present any other places.
-        body << s.to_s.gsub(U2028, '\u2028').gsub(U2029, '\u2029')
-      end
+        s.gsub(U2028, '\u2028').gsub(U2029, '\u2029')
+      end.join
 
       # https://github.com/rack/rack-contrib/issues/46
       response.close if response.respond_to?(:close)

--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
 
   # A Rack middleware for providing JSON-P support.

--- a/lib/rack/contrib/lazy_conditional_get.rb
+++ b/lib/rack/contrib/lazy_conditional_get.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
 
   ##

--- a/lib/rack/contrib/lighttpd_script_name_fix.rb
+++ b/lib/rack/contrib/lighttpd_script_name_fix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Lighttpd sets the wrong SCRIPT_NAME and PATH_INFO if you mount your
   # FastCGI app at "/". This middleware fixes this issue.

--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'i18n'
 
 module Rack

--- a/lib/rack/contrib/mailexceptions.rb
+++ b/lib/rack/contrib/mailexceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/smtp'
 require 'mail'
 require 'erb'

--- a/lib/rack/contrib/nested_params.rb
+++ b/lib/rack/contrib/nested_params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack/utils'
 
 module Rack

--- a/lib/rack/contrib/not_found.rb
+++ b/lib/rack/contrib/not_found.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Rack::NotFound is a default endpoint. Optionally initialize with the
   # path to a custom 404 page, to override the standard response body.

--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'json'
 rescue LoadError => e

--- a/lib/rack/contrib/printout.rb
+++ b/lib/rack/contrib/printout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   #prints the environment and request for simple debugging
   class Printout

--- a/lib/rack/contrib/proctitle.rb
+++ b/lib/rack/contrib/proctitle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Middleware to update the process title ($0) with information about the
   # current request. Based loosely on:

--- a/lib/rack/contrib/profiler.rb
+++ b/lib/rack/contrib/profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ruby-prof'
 
 module Rack

--- a/lib/rack/contrib/relative_redirect.rb
+++ b/lib/rack/contrib/relative_redirect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack'
 
 # Rack::RelativeRedirect is a simple middleware that converts relative paths in

--- a/lib/rack/contrib/response_cache.rb
+++ b/lib/rack/contrib/response_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'rack'
 

--- a/lib/rack/contrib/response_headers.rb
+++ b/lib/rack/contrib/response_headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Allows you to tap into the response headers. Yields a Rack::Utils::HeaderHash
   # of current response headers to the block. Example:

--- a/lib/rack/contrib/route_exceptions.rb
+++ b/lib/rack/contrib/route_exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class RouteExceptions
     ROUTES = [

--- a/lib/rack/contrib/signals.rb
+++ b/lib/rack/contrib/signals.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Installs signal handlers that are safely processed after a request
   #

--- a/lib/rack/contrib/simple_endpoint.rb
+++ b/lib/rack/contrib/simple_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Create simple endpoints with routing rules, similar to Sinatra actions.
   #

--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 
 module Rack

--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -59,10 +59,12 @@ module Rack
       @no_cache = {}
       @urls.collect! do |url|
         if url  =~ /\*$/
-          url.sub!(/\*$/, '')
-          @no_cache[url] = 1
+          url_prefix = url.sub(/\*$/, '')
+          @no_cache[url_prefix] = 1
+          url_prefix
+        else
+          url
         end
-        url
       end
       root = options[:root] || Dir.pwd
       @file_server = Rack::File.new(root)

--- a/lib/rack/contrib/time_zone.rb
+++ b/lib/rack/contrib/time_zone.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class TimeZone
     Javascript = <<-EOJ

--- a/lib/rack/contrib/try_static.rb
+++ b/lib/rack/contrib/try_static.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
 
   # The Rack::TryStatic middleware delegates requests to Rack::Static middleware

--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'git-version-bump'
 rescue LoadError

--- a/test/mail_settings.rb
+++ b/test/mail_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 TEST_SMTP = nil
 
 # Enable SMTP tests by providing the following for your SMTP server.

--- a/test/spec_rack_access.rb
+++ b/test/spec_rack_access.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/access'

--- a/test/spec_rack_backstage.rb
+++ b/test/spec_rack_backstage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/builder'
 require 'rack/mock'

--- a/test/spec_rack_bounce_favicon.rb
+++ b/test/spec_rack_bounce_favicon.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/bounce_favicon'

--- a/test/spec_rack_callbacks.rb
+++ b/test/spec_rack_callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/callbacks'

--- a/test/spec_rack_common_cookies.rb
+++ b/test/spec_rack_common_cookies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/builder'

--- a/test/spec_rack_config.rb
+++ b/test/spec_rack_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/config'

--- a/test/spec_rack_contrib.rb
+++ b/test/spec_rack_contrib.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/contrib'
 

--- a/test/spec_rack_cookies.rb
+++ b/test/spec_rack_cookies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/cookies'

--- a/test/spec_rack_csshttprequest.rb
+++ b/test/spec_rack_csshttprequest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 

--- a/test/spec_rack_deflect.rb
+++ b/test/spec_rack_deflect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/deflect'

--- a/test/spec_rack_enforce_valid_encoding.rb
+++ b/test/spec_rack_enforce_valid_encoding.rb
@@ -1,4 +1,5 @@
 # -*- encoding : us-ascii -*-
+# frozen_string_literal: true
 
 require 'minitest/autorun'
 require 'rack/contrib/enforce_valid_encoding'

--- a/test/spec_rack_evil.rb
+++ b/test/spec_rack_evil.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/evil'

--- a/test/spec_rack_expectation_cascade.rb
+++ b/test/spec_rack_expectation_cascade.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/expectation_cascade'

--- a/test/spec_rack_garbagecollector.rb
+++ b/test/spec_rack_garbagecollector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/garbagecollector'

--- a/test/spec_rack_host_meta.rb
+++ b/test/spec_rack_host_meta.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/host_meta'

--- a/test/spec_rack_json_body_parser_spec.rb
+++ b/test/spec_rack_json_body_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/json_body_parser'

--- a/test/spec_rack_jsonp.rb
+++ b/test/spec_rack_jsonp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/jsonp'

--- a/test/spec_rack_lazy_conditional_get.rb
+++ b/test/spec_rack_lazy_conditional_get.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/lazy_conditional_get'

--- a/test/spec_rack_lighttpd_script_name_fix.rb
+++ b/test/spec_rack_lighttpd_script_name_fix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/lighttpd_script_name_fix'

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'minitest/hooks'
 require 'rack/mock'

--- a/test/spec_rack_mailexceptions.rb
+++ b/test/spec_rack_mailexceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 

--- a/test/spec_rack_nested_params.rb
+++ b/test/spec_rack_nested_params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/nested_params'

--- a/test/spec_rack_not_found.rb
+++ b/test/spec_rack_not_found.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/not_found'

--- a/test/spec_rack_post_body_content_type_parser.rb
+++ b/test/spec_rack_post_body_content_type_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 

--- a/test/spec_rack_proctitle.rb
+++ b/test/spec_rack_proctitle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/proctitle'

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 

--- a/test/spec_rack_relative_redirect.rb
+++ b/test/spec_rack_relative_redirect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/relative_redirect'

--- a/test/spec_rack_response_cache.rb
+++ b/test/spec_rack_response_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack/mock'
 require 'rack/contrib/response_cache'

--- a/test/spec_rack_response_headers.rb
+++ b/test/spec_rack_response_headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack'
 require 'rack/contrib/response_headers'

--- a/test/spec_rack_simple_endpoint.rb
+++ b/test/spec_rack_simple_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'rack'
 require 'rack/contrib/simple_endpoint'

--- a/test/spec_rack_static_cache.rb
+++ b/test/spec_rack_static_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 
 require 'rack'

--- a/test/spec_rack_static_cache.rb
+++ b/test/spec_rack_static_cache.rb
@@ -52,8 +52,8 @@ describe "Rack::StaticCache" do
       next_year = Time.now().year + 1
       _(get_request("/statics/test").headers['Expires']).must_match(
         Regexp.new(
-          "[A-Z][a-z]{2}[,][\s][0-9]{2}[\s][A-Z][a-z]{2}[\s]" <<
-          "#{next_year}" <<
+          "[A-Z][a-z]{2}[,][\s][0-9]{2}[\s][A-Z][a-z]{2}[\s]" +
+          "#{next_year}" +
           "[\s][0-9]{2}[:][0-9]{2}[:][0-9]{2} GMT$"
         )
       )

--- a/test/spec_rack_try_static.rb
+++ b/test/spec_rack_try_static.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 
 require 'rack'


### PR DESCRIPTION
## Changes
- added `# frozen_string_literal: true` magic comment in all the Ruby source code files
- refactored code and tests to avoid strings modification

## Concerns

There were introduced changes in `Rack::CSSHTTPRequest` and `Rack::JSONP` middlewares which could be considered as breaking. Explicit conversion of body chunks to String was removed. But I think it's completely OK as far as Rack specification requires body chunks to be already String.

Please let me know if we should keep current behavior for backward compatibility and revert these  changes.