### PR TITLE
Repair `lib/rack/contrib/runtime` file to make Rack::Runtime available

### DIFF
--- a/lib/rack/contrib/runtime.rb
+++ b/lib/rack/contrib/runtime.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'rack'
+require 'rack/runtime'

--- a/test/spec_rack_runtime.rb
+++ b/test/spec_rack_runtime.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'rack/contrib/runtime'
+
+describe "Rack::Runtime" do
+  specify "exists and sets X-Runtime header" do
+    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, "Hello, World!"] }
+    response = Rack::Runtime.new(app).call({})
+    _(response[1]['X-Runtime']).must_match /[\d\.]+/
+  end
+end


### PR DESCRIPTION
## Changes
- created `rack/contrib/runtime.rb` file
- added minimalistic specs

Related PR:
- https://github.com/rack/rack-contrib/pull/170

## Notes

`Rack::Runtime` was removed recently [here](https://github.com/rack/rack-contrib/pull/170) but because there is already compatible version in `rack` itself. But in order to support backward compatibility and allow to require this middleware directly, e.g.
 
```ruby
require 'rack/contrib/runtime'
```
we have to keep the file.