### PR TITLE
Fix some thread-safety issues

### DIFF
--- a/lib/rack/contrib/access.rb
+++ b/lib/rack/contrib/access.rb
@@ -50,9 +50,9 @@ module Rack
     end
 
     def call(env)
-      @original_request = Request.new(env)
+      request = Request.new(env)
       ipmasks = ipmasks_for_path(env)
-      return forbidden! unless ip_authorized?(ipmasks)
+      return forbidden! unless ip_authorized?(request, ipmasks)
       status, headers, body = @app.call(env)
       [status, headers, body]
     end
@@ -75,11 +75,11 @@ module Rack
       [403, { 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
     end
 
-    def ip_authorized?(ipmasks)
+    def ip_authorized?(request, ipmasks)
       return true if ipmasks.nil?
 
       ipmasks.any? do |ip_mask|
-        ip_mask.include?(IPAddr.new(@original_request.ip))
+        ip_mask.include?(IPAddr.new(request.ip))
       end
     end
 

--- a/lib/rack/contrib/common_cookies.rb
+++ b/lib/rack/contrib/common_cookies.rb
@@ -13,20 +13,20 @@ module Rack
 
     def call(env)
       @app.call(env).tap do |(status, headers, response)|
-        @host = env['HTTP_HOST'].sub PORT, ''
-        share_cookie headers
+        host = env['HTTP_HOST'].sub PORT, ''
+        share_cookie(headers, host)
       end
     end
 
     private
 
-    def domain
-      @host =~ DOMAIN_REGEXP
+    def domain(host)
+      host =~ DOMAIN_REGEXP
       ".#{$1}.#{$2}"
     end
 
-    def share_cookie(headers)
-      headers['Set-Cookie'] &&= common_cookie(headers) if @host !~ LOCALHOST_OR_IP_REGEXP
+    def share_cookie(headers, host)
+      headers['Set-Cookie'] &&= common_cookie(headers, host) if host !~ LOCALHOST_OR_IP_REGEXP
     end
 
     def cookie(headers)
@@ -34,8 +34,8 @@ module Rack
       cookies.is_a?(Array) ? cookies.join("\n") : cookies
     end
 
-    def common_cookie(headers)
-      cookie(headers).gsub(/; domain=[^;]*/, '').gsub(/$/, "; domain=#{domain}")
+    def common_cookie(headers, host)
+      cookie(headers).gsub(/; domain=[^;]*/, '').gsub(/$/, "; domain=#{domain(host)}")
     end
   end
 end

--- a/lib/rack/contrib/lazy_conditional_get.rb
+++ b/lib/rack/contrib/lazy_conditional_get.rb
@@ -45,6 +45,10 @@ module Rack
   # know for sure that it does not modify the cached content, you can set the
   # `Rack-Lazy-Conditional-Get` on response to `skip`. This will not update the
   # global modification date.
+  #
+  # NOTE: This will not work properly in a multi-threaded environment with
+  # default cache object. A provided cache object should ensure thread-safety
+  # of the `get`/`set`/`[]`/`[]=` methods.
 
   class LazyConditionalGet
 

--- a/test/spec_rack_deflect.rb
+++ b/test/spec_rack_deflect.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'timecop'
 require 'rack/mock'
 require 'rack/contrib/deflect'
 


### PR DESCRIPTION
Some middleware use instance variables and it makes it not thread-safe.

Changes:
- fixed Rack::Access
- fixed Rack::CommonCookies
- fixed Rack::Deflect
- added warning for Rack::LazyConditionalGet