### PR TITLE
Fix issue with response headers case-insensitivity

### DIFF
--- a/lib/rack/contrib/common_cookies.rb
+++ b/lib/rack/contrib/common_cookies.rb
@@ -12,10 +12,13 @@ module Rack
     end
 
     def call(env)
-      @app.call(env).tap do |(status, headers, response)|
-        host = env['HTTP_HOST'].sub PORT, ''
-        share_cookie(headers, host)
-      end
+      status, headers, body = @app.call(env)
+      headers = Utils::HeaderHash.new(headers)
+
+      host = env['HTTP_HOST'].sub PORT, ''
+      share_cookie(headers, host)
+
+      [status, headers, body]
     end
 
     private

--- a/lib/rack/contrib/csshttprequest.rb
+++ b/lib/rack/contrib/csshttprequest.rb
@@ -15,6 +15,8 @@ module Rack
     # the CSSHTTPRequest encoder
     def call(env)
       status, headers, response = @app.call(env)
+      headers = Utils::HeaderHash.new(headers)
+
       if chr_request?(env)
         encoded_response = encode(response)
         modify_headers!(headers, encoded_response)

--- a/lib/rack/contrib/lazy_conditional_get.rb
+++ b/lib/rack/contrib/lazy_conditional_get.rb
@@ -76,7 +76,10 @@ module Rack
       if reading? env and fresh? env
         return [304, {'Last-Modified' => env['HTTP_IF_MODIFIED_SINCE']}, []]
       end
+
       status, headers, body = @app.call env
+      headers = Utils::HeaderHash.new(headers)
+
       update_cache unless (reading?(env) or skipping?(headers))
       headers['Last-Modified'] = cached_value if stampable? headers
       [status, headers, body]

--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -16,6 +16,7 @@ module Rack
 
       env['rack.locale'] = I18n.locale = locale.to_s
       status, headers, body = @app.call(env)
+      headers = Utils::HeaderHash.new(headers)
 
       unless headers['Content-Language']
         headers['Content-Language'] = locale.to_s

--- a/lib/rack/contrib/static_cache.rb
+++ b/lib/rack/contrib/static_cache.rb
@@ -85,7 +85,10 @@ module Rack
         if @versioning_enabled
           path.sub!(@version_regex, '\1')
         end
+
         status, headers, body = @file_server.call(env)
+        headers = Utils::HeaderHash.new(headers)
+
         if @no_cache[url].nil?
           headers['Cache-Control'] ="max-age=#{@duration_in_seconds}, public"
           headers['Expires'] = duration_in_words

--- a/test/spec_rack_response_cache.rb
+++ b/test/spec_rack_response_cache.rb
@@ -91,7 +91,7 @@ describe Rack::ResponseCache do
 
   specify "should pass the environment and response to the block" do
     e, r = nil, nil
-    request(:rc_block=>proc{|env,res| e, r = env, res; nil})
+    request(:rc_block=>proc{|env,res| e, r = env, [res[0], res[1].dup, res[2].dup]; nil})
     _(e['PATH_INFO']).must_equal @def_path
     _(e['REQUEST_METHOD']).must_equal 'GET'
     _(e['QUERY_STRING']).must_equal ''


### PR DESCRIPTION
As far as HTTP headers names are case-insensitive a middleware cannot rely on conventional format of a header name. An application can return unexpected but still valid header name e.g. `CONTENT-TYPE` instead of conventional `Content-Type`.

There is a `Rack::Utils::HeaderHash` class in the `rack` gem which wraps headers and makes it case-insensitive. So there all the middleware which get or set response headers are updated in order to use `Rack::Utils::HeaderHash`.

Changes:
- updated Rack::CommonCookies
- updated Rack::CSSHTTPHeaders
- updated Rack::LazyConditionGet
- updated Rack::Locale
- updated Rack::RelativeRedirect
- updated Rack::ResponseCache
- updated Rack::StaticCache
