### PR TITLE
Fix CSSHTTPRequest - body conforms to Rack SPEC

### DIFF
--- a/lib/rack/contrib/csshttprequest.rb
+++ b/lib/rack/contrib/csshttprequest.rb
@@ -16,8 +16,9 @@ module Rack
     def call(env)
       status, headers, response = @app.call(env)
       if chr_request?(env)
-        response = encode(response)
-        modify_headers!(headers, response)
+        encoded_response = encode(response)
+        modify_headers!(headers, encoded_response)
+        response = [encoded_response]
       end
       [status, headers, response]
     end

--- a/test/spec_rack_csshttprequest.rb
+++ b/test/spec_rack_csshttprequest.rb
@@ -46,6 +46,11 @@ begin
           'csshttprequest.chr' => true, :fatal => true)
       end
 
+      specify "should return encoded body" do
+        body = css_httl_request(@app).call(@request)[2]
+        _(body.to_enum.to_a.join).must_equal @encoded_body
+      end
+
       specify "should modify the content length to the correct value" do
         headers = css_httl_request(@app).call(@request)[1]
         _(headers['Content-Length']).must_equal @encoded_body.length.to_s


### PR DESCRIPTION
Return enumerable (Array) body in `CSSHTTPRequest` instead of string.

### Note

As far as nobody complained about this issue for many years looks like nobody uses it and it can be dropped from the gem.

It makes sense to revise all the middleware and keep only actual and which are in use now.