### PR TITLE
Remove Rack::Config middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ interface:
 * `Rack::BounceFavicon` - Returns a 404 for requests to `/favicon.ico`
 * `Rack::CSSHTTPRequest` - Adds CSSHTTPRequest support by encoding responses as CSS for cross-site AJAX-style data loading
 * `Rack::Callbacks` - Implements DSL for pure before/after filter like Middlewares.
-* `Rack::Config` - Shared configuration for cooperative middleware.
 * `Rack::Cookies` - Adds simple cookie jar hash to env
 * `Rack::Deflect` - Helps protect against DoS attacks.
 * `Rack::Evil` - Lets the rack application return a response to the client from any place.

--- a/lib/rack/contrib/config.rb
+++ b/lib/rack/contrib/config.rb
@@ -1,18 +1,4 @@
 # frozen_string_literal: true
 
-module Rack
-
-  # Rack::Config modifies the environment using the block given during
-  # initialization.
-  class Config
-    def initialize(app, &block)
-      @app = app
-      @block = block
-    end
-
-    def call(env)
-      @block.call(env)
-      @app.call(env)
-    end
-  end
-end
+require 'rack'
+require 'rack/config'


### PR DESCRIPTION
`Rack::Config` was imported to the `rack` gem in 2009 year (https://github.com/rack/rack/commit/a1534a5d7b48812e1e67d7ff02ef53b70e3ea492) so it doesn't make sense to keep the copy here in `rack-contrib`.

https://github.com/rack/rack/blob/2-2-stable/lib/rack/config.rb

Changes:
- removed Rack::Config
- keep the file and require a middleware from the `rack` gem
- updated Readme - removed the Rack::Config from the middleware list