### PR TITLE
Convert response status to Integer with to_i method call

### DIFF
--- a/lib/rack/contrib/jsonp.rb
+++ b/lib/rack/contrib/jsonp.rb
@@ -38,7 +38,7 @@ module Rack
 
       status, headers, response = @app.call(env)
 
-      if STATUS_WITH_NO_ENTITY_BODY.include?(status)
+      if STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i)
         return status, headers, response
       end
 

--- a/lib/rack/contrib/relative_redirect.rb
+++ b/lib/rack/contrib/relative_redirect.rb
@@ -35,7 +35,7 @@ class Rack::RelativeRedirect
     status, headers, body = @app.call(env)
     headers = Rack::Utils::HeaderHash.new(headers)
 
-    if [301,302,303, 307,308].include?(status) and loc = headers['Location'] and !%r{\Ahttps?://}o.match(loc)
+    if [301,302,303, 307,308].include?(status.to_i) and loc = headers['Location'] and !%r{\Ahttps?://}o.match(loc)
       absolute = @absolute_proc.call(env, [status, headers, body])
       headers['Location'] = if %r{\A/}.match(loc)
         "#{absolute}#{loc}"

--- a/lib/rack/contrib/response_cache.rb
+++ b/lib/rack/contrib/response_cache.rb
@@ -55,7 +55,7 @@ class Rack::ResponseCache
     status, headers, body = @app.call(env)
     headers = Rack::Utils::HeaderHash.new(headers)
 
-    if env['REQUEST_METHOD'] == 'GET' and env['QUERY_STRING'] == '' and status == 200 and path = @path_proc.call(env, [status, headers, body])
+    if env['REQUEST_METHOD'] == 'GET' and env['QUERY_STRING'] == '' and status.to_i == 200 and path = @path_proc.call(env, [status, headers, body])
       if @cache.is_a?(String)
         path = File.join(@cache, path) if @cache
         FileUtils.mkdir_p(File.dirname(path))

--- a/lib/rack/contrib/try_static.rb
+++ b/lib/rack/contrib/try_static.rb
@@ -30,7 +30,7 @@ module Rack
       found = nil
       @try.each do |path|
         resp = @static.call(env.merge!({'PATH_INFO' => orig_path + path}))
-        break if !(403..405).include?(resp[0]) && found = resp
+        break if !(403..405).include?(resp[0].to_i) && found = resp
       end
       found or @app.call(env.merge!('PATH_INFO' => orig_path))
     end


### PR DESCRIPTION
The specification require response status to have only method `to_i` to convert it to Integer. Some middleware treat it as Integer itself.

Here was added explicit conversion to Integer.

Changes:
- fixed Rack::JSONP
- fixed Rack::RelativeRedirect
- fixed Rack::ResponseCache
- fixed Rack::TryStatic