### PR TITLE
Rack::JSONBodyParser. Do not rescue JSON:ParserError

### DIFF
--- a/test/spec_rack_json_body_parser_spec.rb
+++ b/test/spec_rack_json_body_parser_spec.rb
@@ -66,6 +66,12 @@ describe Rack::JSONBodyParser do
     _(result).must_be_empty
   end
 
+  specify "should not rescue JSON:ParserError raised by the app" do
+    env = mock_env
+    app = ->(env) { raise JSON::ParserError }
+    _( -> { create_parser(app).call(env) }).must_raise JSON::ParserError
+  end
+
   describe "contradiction between body and type" do
     specify "should return bad request with a JSON-encoded error message" do
       env = mock_env(input: 'This is not JSON')


### PR DESCRIPTION
Do not rescue JSON:ParserError if it was raised inside de app.

I was trying to figure out why my app was returning 400 until I found that it was due to a `JSON::ParserError` rescued by this middleware.

This PR makes the `rescue` block to only catch this exception if it was raised when parsing the params and not when it was raised by the app.