### PR TITLE
Remove another crazy `JSONBodyParser` spec

### DIFF
--- a/test/spec_rack_json_body_parser_spec.rb
+++ b/test/spec_rack_json_body_parser_spec.rb
@@ -58,14 +58,6 @@ describe Rack::JSONBodyParser do
     _(res[2].to_enum.to_a.join).must_equal %Q({"{\\"key\\": \\"value\\"}"=>nil})
   end
 
-  specify "should not create additions" do
-    before = Symbol.all_symbols
-    env = mock_env(input: %{{"json_class":"this_should_not_be_added"}})
-    create_parser(app).call(env)
-    result = Symbol.all_symbols - before
-    _(result).must_be_empty
-  end
-
   specify "should not rescue JSON:ParserError raised by the app" do
     env = mock_env
     app = ->(env) { raise JSON::ParserError }


### PR DESCRIPTION
Triggered by

    TESTOPTS=--seed=8264 b e rake

Seen in CI: https://github.com/rack/rack-contrib/actions/runs/6319320196/job/17160038534#step:4:88

I don't think we should be checking this.

See https://github.com/rack/rack-contrib/commit/161eb9d190848254c331810e06feeaad25ec16aa