### PR TITLE
Treat locales with variants case insensitively

### DIFF
--- a/lib/rack/contrib/locale.rb
+++ b/lib/rack/contrib/locale.rb
@@ -75,7 +75,7 @@ module Rack
         matched_locale = I18n.available_locales.find { |al| match?(al, locale) } if locale
         if !locale && !matched_locale
           matched_locale = locales.reverse.find { |locale| I18n.available_locales.any? { |al| variant_match?(al, locale) } }
-          matched_locale = matched_locale[0,2] if matched_locale
+          matched_locale = matched_locale[0,2].downcase if matched_locale
         end
         matched_locale
       else

--- a/test/spec_rack_locale.rb
+++ b/test/spec_rack_locale.rb
@@ -75,6 +75,10 @@ begin
       _(response_with_languages('pt;Q=0.9,es-CL').body).must_equal('es')
     end
 
+    specify 'should match languages with variants case insensitively' do
+      _(response_with_languages('pt;Q=0.9,ES-CL').body).must_equal('es')
+    end
+
     specify 'should skip * if it is followed by other languages' do
       _(response_with_languages('*,dk;q=0.5').body).must_equal('dk')
     end


### PR DESCRIPTION
We've noticed a few clients sending along funny locales like `English`
<img width="1254" alt="Screenshot 2024-10-30 at 12 18 47 PM" src="https://github.com/user-attachments/assets/5b3b7763-1817-4591-88f9-76bd056f92cc">

These result in the following error:
```
I18n::InvalidLocale: "En" is not a valid locale
```

That's happening because the locale variant match is case insensitive:
https://github.com/rack/rack-contrib/blob/main/lib/rack/contrib/locale.rb#L91

But then the locale is extracted without a downcase.

I believe it should be safe to just downcase the locale from the client in these cases.